### PR TITLE
Escape uppercase Swift keywords in @IsCase

### DIFF
--- a/Sources/QizhMacroKitMacros/Helpers/String+swiftKeywordEscaping.swift
+++ b/Sources/QizhMacroKitMacros/Helpers/String+swiftKeywordEscaping.swift
@@ -14,13 +14,13 @@ private let swiftKeywords: Set<String> = [
         "var", "break", "case", "catch", "continue", "default", "defer",
         "do", "else", "fallthrough", "for", "guard", "if", "in", "repeat",
         "return", "throw", "throws", "rethrows", "where", "while", "as",
-        "is", "try", "super", "self", "Self", "any", "switch", "macro",
+        "is", "try", "super", "self", "any", "switch", "macro",
         "actor", "await", "async", "final", "open", "some"
 ]
 
 extension String {
         /// Returns the string wrapped in backticks if it is a Swift reserved keyword.
         internal var escapedSwiftIdentifier: String {
-                swiftKeywords.contains(self) ? "`\(self)`" : self
+                swiftKeywords.contains(self.lowercased()) ? "`\(self)`" : self
         }
 }

--- a/Tests/IsCaseTests/IsCaseTests.swift
+++ b/Tests/IsCaseTests/IsCaseTests.swift
@@ -45,4 +45,18 @@ struct IsCaseMacroTests {
                 #expect(nextAction.isAmong([.setup, .update, .sync]))
                 #expect(!nextAction.isAmong(.export, .import))
         }
+
+        @Test("Escapes uppercase Swift keywords")
+        func escapesUppercaseSwiftKeywords() {
+                @IsCase
+                enum Keywords {
+                        case `Any`
+                        case value
+                }
+
+                let keyword: Keywords = .Any
+                #expect(keyword.isAny)
+                #expect(!keyword.isValue)
+                #expect(keyword.isAmong(.`Any`))
+        }
 }


### PR DESCRIPTION
## Summary
- ensure Swift keyword escaping performs case-insensitive lookup
- add regression test for enum case named `Any`

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68b3e80d9e98832eaf1af59471713259