### PR TITLE
Add experimental Labeled macro

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "35018be1d49ab4c27906b6935d6f5f21b5986f0cd8a9d22312a35799791b7ae6",
+  "originHash" : "07f04e060d3bf5fa41beaf15505e3ebde95c3b9f9e4d50987c05c59abc3bbb33",
   "pins" : [
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
+        "version" : "1.2.1"
+      }
+    },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
 	],
         dependencies: [
                 .package(url: "https://github.com/swiftlang/swift-syntax.git", "601.0.0" ..< "700.0.0"),
-                // .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.2.0")),
+                .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.2.0")),
                 .package(url: "https://github.com/apple/swift-testing.git", branch: "main"),
 
         ],
@@ -44,8 +44,8 @@ let package = Package(
 				.product(name: "SwiftSyntax", package: "swift-syntax"),
 				.product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
 				.product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
-				.product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
-				// .product(name: "OrderedCollections", package: "swift-collections"),
+                                .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
+                                .product(name: "OrderedCollections", package: "swift-collections"),
 			]
 		),
 		
@@ -53,9 +53,9 @@ let package = Package(
 		
 		.target(
 			name: "QizhMacroKit",
-			dependencies: [
-				// .product(name: "OrderedCollections", package: "swift-collections"),
-			],
+                        dependencies: [
+                                .product(name: "OrderedCollections", package: "swift-collections"),
+                        ],
 			resources: [
 				.process("PrivacyInfo.xcprivacy")
 			],
@@ -98,6 +98,7 @@ let package = Package(
                                 "QizhMacroKitMacros",
                                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
                                 .product(name: "Testing", package: "swift-testing"),
+                                .product(name: "OrderedCollections", package: "swift-collections"),
                         ],
                         path: "Tests"
                 ),

--- a/Sources/QizhMacroKit/Labeled.swift
+++ b/Sources/QizhMacroKit/Labeled.swift
@@ -1,0 +1,13 @@
+//
+//  Labeled.swift
+//  QizhMacroKit
+//
+//  Created by OpenAI ChatGPT on 13.01.2025.
+//
+
+@attached(peer, names: arbitrary)
+/// Attribute that converts an array literal into an ``OrderedDictionary`` keyed by the element expressions.
+public macro Labeled() = #externalMacro(module: "QizhMacroKitMacros", type: "LabeledGenerator")
+
+@_exported import OrderedCollections
+

--- a/Sources/QizhMacroKitMacros/LabeledGenerator.swift
+++ b/Sources/QizhMacroKitMacros/LabeledGenerator.swift
@@ -1,0 +1,60 @@
+//
+//  LabeledGenerator.swift
+//  QizhMacroKit
+//
+//  Created by OpenAI ChatGPT on 13.01.2025.
+//
+
+/// Attribute macro that transforms an array literal into an ``OrderedDictionary`` whose keys are derived from the element expressions.
+public struct LabeledGenerator: DeclarationMacro {
+    /// Expands the variable declaration annotated with ``@Labeled`` into an ``OrderedDictionary`` initializer.
+    /// - Parameters:
+    ///   - node: The macro attribute syntax.
+    ///   - declaration: The declaration the macro is attached to.
+    ///   - context: Contextual information for the macro expansion.
+    /// - Returns: Replacement declarations forming an ``OrderedDictionary``.
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingDeclarationsOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let varDecl = declaration.as(VariableDeclSyntax.self),
+              let binding = varDecl.bindings.first,
+              let arrayExpr = binding.initializer?.value.as(ArrayExprSyntax.self) else {
+            return []
+        }
+
+        let patternText = binding.pattern.description.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        var entries: [String] = []
+        for element in arrayExpr.elements {
+            let expr = element.expression.description.trimmingCharacters(in: .whitespacesAndNewlines)
+            let key: String
+            if let declRef = element.expression.as(DeclReferenceExprSyntax.self) {
+                key = declRef.baseName.text.withBackticksTrimmed
+            } else {
+                key = expr
+            }
+            entries.append("\"\(key)\": \(expr)")
+        }
+        let body = entries.joined(separator: ",\n\t\t")
+
+        let dictType: String
+        if let typeAnn = binding.typeAnnotation?.type.description.trimmingCharacters(in: .whitespacesAndNewlines) {
+            if typeAnn.hasPrefix("[") && typeAnn.hasSuffix("]") {
+                let elementType = String(typeAnn.dropFirst().dropLast()).trimmingCharacters(in: .whitespacesAndNewlines)
+                dictType = "OrderedDictionary<String, \(elementType)>"
+            } else {
+                dictType = "OrderedDictionary<String, \(typeAnn)>"
+            }
+        } else {
+            dictType = "OrderedDictionary"
+        }
+
+        let modifiers = varDecl.modifiers?.description ?? ""
+        let specifier = varDecl.bindingSpecifier.text
+        let result = "\(modifiers)\(specifier) \(patternText): \(dictType) = [\n\t\t\(body)\n]"
+        return ["\(raw: result)"]
+    }
+}
+

--- a/Sources/QizhMacroKitMacros/_QizhMacroKitMacro.swift
+++ b/Sources/QizhMacroKitMacros/_QizhMacroKitMacro.swift
@@ -10,8 +10,9 @@ struct QizhMacroKitPlugin: CompilerPlugin {
 		IsCasesGenerator.self,
 		IsNotCasesGenerator.self,
 		CaseNameGenerator.self,
-		CaseValueGenerator.self,
-		StringifyGenerator.self,
-		DictionarifyGenerator.self,
-	]
+                CaseValueGenerator.self,
+                StringifyGenerator.self,
+                DictionarifyGenerator.self,
+                LabeledGenerator.self,
+        ]
 }

--- a/Tests/LabeledTests/LabeledMacroTests.swift
+++ b/Tests/LabeledTests/LabeledMacroTests.swift
@@ -1,0 +1,52 @@
+import Testing
+import QizhMacroKit
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import SwiftSyntaxMacrosGenericTestSupport
+import QizhMacroKitMacros
+import OrderedCollections
+
+/// Tests for the ``Labeled`` macro.
+@Suite("Labeled macro")
+struct LabeledMacroTests {
+/// Macro implementations under test.
+let macros: [String: any Macro.Type] = [
+"Labeled": LabeledGenerator.self,
+]
+
+/// Ensures the array expands to an ``OrderedDictionary``.
+@Test("expands array to OrderedDictionary")
+func expandsToOrderedDictionary() {
+assertMacroExpansion(
+#"""
+@Labeled
+let names = [
+firstName,
+lastName,
+]
+"""#,
+expandedSource:
+#"""
+let names: OrderedDictionary = [
+"firstName": firstName,
+"lastName": lastName,
+]
+"""#,
+macros: macros
+)
+}
+
+/// Uses the macro at runtime.
+@Test("runtime dictionary")
+func runtimeDictionary() {
+let firstName = "Serhii"
+let lastName = "Shevchenko"
+@Labeled let dict = [
+firstName,
+lastName,
+]
+#expect(dict.keys.first == "firstName")
+#expect(dict["lastName"] == lastName)
+}
+}
+


### PR DESCRIPTION
## Summary
- add experimental `@Labeled` macro intended to turn array literals into `OrderedDictionary`
- expose macro from library and include OrderedCollections dependency
- draft tests covering macro expansion and runtime behavior

## Testing
- `swift test` *(fails: type 'LabeledGenerator' does not conform to protocol 'DeclarationMacro')*

------
https://chatgpt.com/codex/tasks/task_e_68b68672ee9c832eb2f6e5dcc21cd057