### PR TITLE
Enhancements to `WithEnvironmentGenerator` Macro for Improved Environment Variable Handling

### DIFF
--- a/Sources/QizhMacroKitMacros/WithEnvironmentGenerator.swift
+++ b/Sources/QizhMacroKitMacros/WithEnvironmentGenerator.swift
@@ -131,7 +131,7 @@ public struct WithEnvironmentGenerator: CodeItemMacro {
 					continue
 				}
 
-				if classification == .unsupported {
+				if classification == .defaultEnvironment {
 					context.diagnose(.warning(
 						node: Syntax(binding),
 						message: "\(typeText) requires @EnvironmentObject or @Environment attribute. Defaulting to @Environment.",
@@ -159,8 +159,8 @@ public struct WithEnvironmentGenerator: CodeItemMacro {
 				return .environment
 			}
 		}
-		// Default to .environment for plain variable declarations (most common case for @Observable types)
-		return .unsupported
+		// No explicit attribute specified; will default to @Environment with a warning
+		return .defaultEnvironment
 	}
 
 	private static func makeStructName(from explicit: String?, seed: String) -> String {
@@ -227,10 +227,7 @@ private struct EnvironmentVariable {
 		switch classification {
 		case .environmentObject:
 			"@EnvironmentObject private var \(name): \(type)"
-		case .environment:
-			"@Environment(\(type).self) private var \(name)"
-		case .unsupported:
-			// Default to @Environment for types without explicit attribute
+		case .environment, .defaultEnvironment:
 			"@Environment(\(type).self) private var \(name)"
 		}
 	}
@@ -241,5 +238,6 @@ private struct EnvironmentVariable {
 private enum EnvironmentClassification {
 	case environmentObject
 	case environment
-	case unsupported
+	/// No explicit attribute was specified; defaults to @Environment with a warning
+	case defaultEnvironment
 }

--- a/Sources/QizhMacroKitMacros/WithEnvironmentGenerator.swift
+++ b/Sources/QizhMacroKitMacros/WithEnvironmentGenerator.swift
@@ -215,7 +215,7 @@ private struct EnvironmentVariable {
 		case .unsupported:
 			"""
 			@available(*, unavailable, message: "Unsupported environment variable type: \(type)")
-			private var \(name): \(type) { fatalError("Unsupported environment variable type: \(type)") }
+			private var \(name): \(type) {}
 			"""
 		}
 	}

--- a/Sources/QizhMacroKitMacros/WithEnvironmentGenerator.swift
+++ b/Sources/QizhMacroKitMacros/WithEnvironmentGenerator.swift
@@ -213,7 +213,10 @@ private struct EnvironmentVariable {
 		case .environment:
 			"@Environment(\(type).self) private var \(name)"
 		case .unsupported:
-			"@available(*, unavailable, message: \"Unsupported environment variable type: \(type)\")\nprivate var \(name): \(type) { fatalError(\"Unsupported environment variable type: \(type)\") }"
+			"""
+			@available(*, unavailable, message: "Unsupported environment variable type: \(type)")
+			private var \(name): \(type) { fatalError("Unsupported environment variable type: \(type)") }
+			"""
 		}
 	}
 


### PR DESCRIPTION
This pull request updates the `WithEnvironmentGenerator` macro to improve how environment variables are classified and handled, particularly when attributes like `@EnvironmentObject` or `@Environment` are missing. The changes simplify the logic for determining environment variable types and improve diagnostics for developers.

**Environment variable classification and handling:**

* Added a new method `classifyFromAttributes` to inspect variable declaration attributes and determine if `@EnvironmentObject` or `@Environment` is specified, defaulting to `@Environment` if neither is present. [[1]](diffhunk://#diff-af141e35d1cb60dc4dee3c2b7ef201b503e49cf0f818ac484acc26293930862bR96-R98) [[2]](diffhunk://#diff-af141e35d1cb60dc4dee3c2b7ef201b503e49cf0f818ac484acc26293930862bR167-R181)
* Updated the diagnostic warning to indicate when a variable is missing an explicit environment attribute, and clarified the message to recommend using `@EnvironmentObject` or `@Environment`.
* Refactored `EnvironmentClassification` to remove the `.unsupported` case and introduce `.defaultEnvironment` for variables without explicit attributes, streamlining environment variable code generation. [[1]](diffhunk://#diff-af141e35d1cb60dc4dee3c2b7ef201b503e49cf0f818ac484acc26293930862bL252-R266) [[2]](diffhunk://#diff-af141e35d1cb60dc4dee3c2b7ef201b503e49cf0f818ac484acc26293930862bL239-L242)

**Test improvements:**

* Updated macro expansion tests to use explicit environment attributes and added a test to verify that variables without an explicit attribute default to `@Environment` and produce the correct warning. [[1]](diffhunk://#diff-c4a1312462cda2689cd5f59ec767a70fe9a5feae7c52caa60ba496c55b9b7ab7L28-R29) [[2]](diffhunk://#diff-c4a1312462cda2689cd5f59ec767a70fe9a5feae7c52caa60ba496c55b9b7ab7L52-R77)

<details><summary>Previous PR Summary</summary>
## Summary
- resolve environment variable handling through type-constrained binding helpers instead of string matching
- update macro expansion expectations to use binding resolvers and correct unsupported hash seed escaping

## Testing
- Not run (swift test)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69338efbad14832e9d68b06f59c6c111)</details> 