### PR TITLE
Enhancing `QizhMacroKit` with the well-known but not yet published `@OptionSet` macro

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e9aa1151a5c555cfc5455c63b17c46f39931b5c401689366b9547816f4f50b8b",
+  "originHash" : "9fad6afb0cc9ebdd7527efb0e34f1e4c3ebf95001d531c65ba6a1805d85e970a",
   "pins" : [
     {
       "identity" : "swift-syntax",

--- a/Package.swift
+++ b/Package.swift
@@ -31,9 +31,15 @@ let package = Package(
 	dependencies: [
 		.package(
 			url: "https://github.com/swiftlang/swift-syntax.git",
-			/// Was `"602.0.0" ..< "700.0.0"`
-			/// Was `exact: "602.0.0"`
-			.upToNextMajor(from: "602.0.0")
+			/// Pinned to match Xcode 26.2 / Swift 6.2 toolchain
+			/// to avoid `_SwiftSyntaxCShims` resolution errors
+			/// ## Changelog
+			/// - `"602.0.0" ..< "700.0.0"`
+			/// - `exact: "602.0.0"`
+			/// - `.upToNextMajor(from: "602.0.0")`
+			/// - `exact: "602.1.0"`
+			/// - `branch: "release/6.2"` (matches Xcode 26.2 / Swift 6.2)
+			from: "602.0.0"
 		),
 		// .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.2.0")),
 		/*
@@ -118,3 +124,4 @@ let package = Package(
 		.v6,
 	]
 )
+

--- a/Sources/QizhMacroKit/OptionSet.swift
+++ b/Sources/QizhMacroKit/OptionSet.swift
@@ -1,5 +1,5 @@
 //
-//  Stringify.swift
+//  OptionSet.swift
 //  QizhMacroKit
 //
 //  Created by Serhii Shevchenko on 22.08.2025.

--- a/Sources/QizhMacroKit/OptionSet.swift
+++ b/Sources/QizhMacroKit/OptionSet.swift
@@ -1,0 +1,49 @@
+//
+//  Stringify.swift
+//  QizhMacroKit
+//
+//  Created by Serhii Shevchenko on 22.08.2025.
+//
+
+/// Create an option set from a struct that contains a nested `Options` enum.
+///
+/// Attach this macro to a struct that contains a nested `Options` enum
+/// with an integer raw value. The struct will be transformed to conform to
+/// `OptionSet` by
+/// - 1. Introducing a `rawValue` stored property to track which options are set,
+///   along with the necessary `RawType` typealias and initializers to satisfy
+///   the `OptionSet` protocol.
+/// - 2. Introducing static properties for each of the cases within the `Options`
+///   enum, of the type of the struct.
+/// ## Example
+/// ```swift
+/// @OptionSet<UInt8>
+/// struct ColorApplications {
+/// 	private enum Options: UInt8 {
+/// 		case tint
+/// 		case tintGradient
+/// 		case accent
+/// 	}
+/// }
+/// ```
+/// - Precondition:
+///   The `Options` enum must have a raw value, where its case elements
+///   each indicate a different option in the resulting option set. For example,
+///   the struct and its nested `Options` enum could look like this:
+@attached(member, names: arbitrary)
+@attached(extension, conformances: OptionSet)
+public macro OptionSet<RawType>() =
+	#externalMacro(module: "QizhMacroKitMacros", type: "OptionSetGenerator")
+
+/// Failed attempt to use the implementation directly from `swift-syntax` examples.
+/*
+import SwiftSyntaxMacros
+
+@attached(member, names: named(RawValue), named(rawValue), named(`init`), arbitrary)
+@attached(extension, conformances: OptionSet)
+public macro OptionSet<RawType>() =
+	#externalMacro(
+		module: "SwiftSyntaxMacros",    /// from the swift-syntax package
+		type: "OptionSetMacro"
+	)
+*/

--- a/Sources/QizhMacroKitClient/OptionSet.swift
+++ b/Sources/QizhMacroKitClient/OptionSet.swift
@@ -1,0 +1,18 @@
+//
+//  OptionSet.swift
+//  QizhMacroKit
+//
+//  Created by Serhii Shevchenko on 08.12.2025.
+//
+
+import Foundation
+import QizhMacroKit
+
+@OptionSet<UInt8>
+struct BusinessColorApplications {
+	private enum Options: UInt8 {
+		case tint
+		case tintGradient
+		case accent
+	}
+}

--- a/Sources/QizhMacroKitMacros/OptionSetGenerator.swift
+++ b/Sources/QizhMacroKitMacros/OptionSetGenerator.swift
@@ -1,0 +1,230 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+enum OptionSetMacroDiagnostic {
+	case requiresStruct
+	case requiresStringLiteral(String)
+	case requiresOptionsEnum(String)
+	case requiresOptionsEnumRawType
+}
+
+extension OptionSetMacroDiagnostic: DiagnosticMessage {
+	func diagnose(at node: some SyntaxProtocol) -> Diagnostic {
+		Diagnostic(node: Syntax(node), message: self)
+	}
+
+	var message: String {
+		switch self {
+		case .requiresStruct:
+			return "'OptionSet' macro can only be applied to a struct"
+
+		case .requiresStringLiteral(let name):
+			return "'OptionSet' macro argument \(name) must be a string literal"
+
+		case .requiresOptionsEnum(let name):
+			return "'OptionSet' macro requires nested options enum '\(name)'"
+
+		case .requiresOptionsEnumRawType:
+			return "'OptionSet' macro requires a raw type"
+		}
+	}
+
+	var severity: DiagnosticSeverity { .error }
+
+	var diagnosticID: MessageID {
+		MessageID(domain: "Swift", id: "OptionSet.\(self)")
+	}
+}
+
+/// The label used for the OptionSet macro argument that provides the name of
+/// the nested options enum.
+private let optionsEnumNameArgumentLabel = "optionsName"
+
+/// The default name used for the nested "Options" enum. This should
+/// eventually be overridable.
+private let defaultOptionsEnumName = "Options"
+
+extension LabeledExprListSyntax {
+	/// Retrieve the first element with the given label.
+	func first(labeled name: String) -> Element? {
+		return first { element in
+			if let label = element.label, label.text == name {
+				return true
+			}
+
+			return false
+		}
+	}
+}
+
+public struct OptionSetGenerator {
+	/// Decodes the arguments to the macro expansion.
+	///
+	/// - Returns: the important arguments used by the various roles of this
+	/// macro inhabits, or nil if an error occurred.
+	static func decodeExpansion(
+		of attribute: AttributeSyntax,
+		attachedTo decl: some DeclGroupSyntax,
+		in context: some MacroExpansionContext,
+		emitDiagnostics: Bool
+	) -> (StructDeclSyntax, EnumDeclSyntax, GenericArgumentSyntax.Argument)? {
+		// Determine the name of the options enum.
+		let optionsEnumName: String
+		if case let .argumentList(arguments) = attribute.arguments,
+			let optionEnumNameArg = arguments.first(labeled: optionsEnumNameArgumentLabel)
+		{
+			// We have a options name; make sure it is a string literal.
+			guard let stringLiteral = optionEnumNameArg.expression.as(StringLiteralExprSyntax.self),
+				stringLiteral.segments.count == 1,
+				case let .stringSegment(optionsEnumNameString)? = stringLiteral.segments.first
+			else {
+				if emitDiagnostics {
+					context.diagnose(
+						OptionSetMacroDiagnostic.requiresStringLiteral(optionsEnumNameArgumentLabel).diagnose(
+							at: optionEnumNameArg.expression
+						)
+					)
+				}
+				return nil
+			}
+
+			optionsEnumName = optionsEnumNameString.content.text
+		} else {
+			optionsEnumName = defaultOptionsEnumName
+		}
+
+		// Only apply to structs.
+		guard let structDecl = decl.as(StructDeclSyntax.self) else {
+			if emitDiagnostics {
+				context.diagnose(OptionSetMacroDiagnostic.requiresStruct.diagnose(at: decl))
+			}
+			return nil
+		}
+
+		// Find the option enum within the struct.
+		guard
+			let optionsEnum = decl.memberBlock.members.compactMap({ member in
+				if let enumDecl = member.decl.as(EnumDeclSyntax.self),
+					enumDecl.name.text == optionsEnumName
+				{
+					return enumDecl
+				}
+
+				return nil
+			}).first
+		else {
+			if emitDiagnostics {
+				context.diagnose(OptionSetMacroDiagnostic.requiresOptionsEnum(optionsEnumName).diagnose(at: decl))
+			}
+			return nil
+		}
+
+		// Retrieve the raw type from the attribute.
+		guard let genericArgs = attribute.attributeName.as(IdentifierTypeSyntax.self)?.genericArgumentClause,
+			let rawType = genericArgs.arguments.first?.argument
+		else {
+			if emitDiagnostics {
+				context.diagnose(OptionSetMacroDiagnostic.requiresOptionsEnumRawType.diagnose(at: attribute))
+			}
+			return nil
+		}
+
+		return (structDecl, optionsEnum, rawType)
+	}
+}
+
+extension OptionSetGenerator: ExtensionMacro {
+	public static func expansion(
+		of node: AttributeSyntax,
+		attachedTo declaration: some DeclGroupSyntax,
+		providingExtensionsOf type: some TypeSyntaxProtocol,
+		conformingTo protocols: [TypeSyntax],
+		in context: some MacroExpansionContext
+	) throws -> [ExtensionDeclSyntax] {
+		// Decode the expansion arguments.
+		guard
+			let (structDecl, _, _) = decodeExpansion(of: node, attachedTo: declaration, in: context, emitDiagnostics: false)
+		else {
+			return []
+		}
+
+		// If there is an explicit conformance to OptionSet already, don't add one.
+		if let inheritedTypes = structDecl.inheritanceClause?.inheritedTypes,
+			inheritedTypes.contains(where: { inherited in inherited.type.trimmedDescription == "OptionSet" })
+		{
+			return []
+		}
+
+		return [try ExtensionDeclSyntax("extension \(type): OptionSet {}")]
+	}
+}
+
+extension OptionSetGenerator: MemberMacro {
+	public static func expansion(
+		of attribute: AttributeSyntax,
+		providingMembersOf decl: some DeclGroupSyntax,
+		conformingTo: [TypeSyntax],
+		in context: some MacroExpansionContext
+	) throws -> [DeclSyntax] {
+		// Decode the expansion arguments.
+		guard
+			let (_, optionsEnum, rawType) = decodeExpansion(
+				of: attribute,
+				attachedTo: decl,
+				in: context,
+				emitDiagnostics: true
+			)
+		else {
+			return []
+		}
+
+		// Find all of the case elements.
+		let caseElements: [EnumCaseElementSyntax] = optionsEnum.memberBlock.members.flatMap { member in
+			guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else {
+				return [EnumCaseElementSyntax]()
+			}
+
+			return Array(caseDecl.elements)
+		}
+
+		// Dig out the access control keyword we need.
+		let access = decl.modifiers.first(where: \.isNeededAccessLevelModifier)
+
+		let staticVars = caseElements.map { (element) -> DeclSyntax in
+			"""
+			\(access) static let \(element.name): Self =
+				Self(rawValue: 1 << \(optionsEnum.name).\(element.name).rawValue)
+			"""
+		}
+
+		return [
+			"\(access)typealias RawValue = \(rawType)",
+			"\(access)var rawValue: RawValue",
+			"\(access)init() { self.rawValue = 0 }",
+			"\(access)init(rawValue: RawValue) { self.rawValue = rawValue }",
+		] + staticVars
+	}
+}
+
+extension DeclModifierSyntax {
+	var isNeededAccessLevelModifier: Bool {
+		switch self.name.tokenKind {
+		case .keyword(.public): return true
+		default: return false
+		}
+	}
+}

--- a/Sources/QizhMacroKitMacros/_QizhMacroKitMacro.swift
+++ b/Sources/QizhMacroKitMacros/_QizhMacroKitMacro.swift
@@ -13,5 +13,6 @@ struct QizhMacroKitPlugin: CompilerPlugin {
 		CaseValueGenerator.self,
 		StringifyGenerator.self,
 		DictionarifyGenerator.self,
+		OptionSetGenerator.self,
 	]
 }

--- a/Tests/OptionSetTests/OptionSetMacroTests.swift
+++ b/Tests/OptionSetTests/OptionSetMacroTests.swift
@@ -1,0 +1,221 @@
+//
+//  OptionSetMacroTests.swift
+//  QizhMacroKit
+//
+//  Created by Serhii Shevchenko on 08.12.2025.
+//
+
+#if os(macOS)
+import Testing
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+
+@testable import QizhMacroKit
+@testable import QizhMacroKitMacros
+
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@Suite("OptionSet Macro Tests")
+struct OptionSetMacroTests {
+	private let macros = ["OptionSet": OptionSetGenerator.self]
+	
+	@Test("Expansion on Simple Struct with Enum and Static")
+	func testExpansionOnStructWithNestedEnumAndStatics() {
+		assertMacroExpansion(
+			"""
+			@MyOptionSet<UInt8>
+			struct ShippingOptions {
+				private enum Options: Int {
+					case nextDay
+					case secondDay
+					case priority
+					case standard
+				}
+
+				static let express: ShippingOptions = [.nextDay, .secondDay]
+				static let all: ShippingOptions = [.express, .priority, .standard]
+			}
+			""",
+			expandedSource: """
+				struct ShippingOptions {
+					private enum Options: Int {
+						case nextDay
+						case secondDay
+						case priority
+						case standard
+					}
+
+					static let express: ShippingOptions = [.nextDay, .secondDay]
+					static let all: ShippingOptions = [.express, .priority, .standard]
+
+					typealias RawValue = UInt8
+
+					var rawValue: RawValue
+
+					init() {
+						self.rawValue = 0
+					}
+
+					init(rawValue: RawValue) {
+						self.rawValue = rawValue
+					}
+
+					static let nextDay: Self =
+						Self(rawValue: 1 << Options.nextDay.rawValue)
+
+					static let secondDay: Self =
+						Self(rawValue: 1 << Options.secondDay.rawValue)
+
+					static let priority: Self =
+						Self(rawValue: 1 << Options.priority.rawValue)
+
+					static let standard: Self =
+						Self(rawValue: 1 << Options.standard.rawValue)
+				}
+
+				extension ShippingOptions: OptionSet {
+				}
+				""",
+			macros: macros,
+			indentationWidth: .spaces(2)
+		)
+	}
+
+	@Test("Expansion on Public Struct with Explicit OptionSet Conformance")
+	func testExpansionOnPublicStructWithExplicitOptionSetConformance() {
+		assertMacroExpansion(
+			"""
+			@MyOptionSet<UInt8>
+			public struct ShippingOptions: OptionSet {
+				private enum Options: Int {
+					case nextDay
+					case standard
+				}
+			}
+			""",
+			expandedSource: """
+				public struct ShippingOptions: OptionSet {
+					private enum Options: Int {
+						case nextDay
+						case standard
+					}
+
+					public typealias RawValue = UInt8
+
+					public var rawValue: RawValue
+
+					public init() {
+						self.rawValue = 0
+					}
+
+					public init(rawValue: RawValue) {
+						self.rawValue = rawValue
+					}
+
+					public  static let nextDay: Self =
+						Self(rawValue: 1 << Options.nextDay.rawValue)
+
+					public  static let standard: Self =
+						Self(rawValue: 1 << Options.standard.rawValue)
+				}
+				""",
+			macros: macros,
+			indentationWidth: .spaces(2)
+		)
+	}
+	
+	@Test("Expansion fails on EnumType")
+	func testExpansionFailsOnEnumType() {
+		assertMacroExpansion(
+			"""
+			@MyOptionSet<UInt8>
+			enum Animal {
+				case dog
+			}
+			""",
+			expandedSource: """
+				enum Animal {
+					case dog
+				}
+				""",
+			diagnostics: [
+				DiagnosticSpec(
+					message: "'OptionSet' macro can only be applied to a struct",
+					line: 1,
+					column: 1
+				)
+			],
+			macros: macros,
+			indentationWidth: .spaces(2)
+		)
+	}
+	
+	@Test("Expansion fails on Struct without nested Options enum")
+	func testExpansionFailsWithoutNestedOptionsEnum() {
+		assertMacroExpansion(
+			"""
+			@MyOptionSet<UInt8>
+			struct ShippingOptions {
+				static let express: ShippingOptions = [.nextDay, .secondDay]
+				static let all: ShippingOptions = [.express, .priority, .standard]
+			}
+			""",
+			expandedSource: """
+				struct ShippingOptions {
+					static let express: ShippingOptions = [.nextDay, .secondDay]
+					static let all: ShippingOptions = [.express, .priority, .standard]
+				}
+				""",
+			diagnostics: [
+				DiagnosticSpec(
+					message: "'OptionSet' macro requires nested options enum 'Options'",
+					line: 1,
+					column: 1
+				)
+			],
+			macros: macros,
+			indentationWidth: .spaces(2)
+		)
+	}
+	
+	@Test("Expansion fails on Struct without specified RawType")
+	func testExpansionFailsWithoutSpecifiedRawType() {
+		assertMacroExpansion(
+			"""
+			@MyOptionSet
+			struct ShippingOptions {
+				private enum Options: Int {
+					case nextDay
+				}
+			}
+			""",
+			expandedSource: """
+				struct ShippingOptions {
+					private enum Options: Int {
+						case nextDay
+					}
+				}
+				""",
+			diagnostics: [
+				DiagnosticSpec(
+					message: "'OptionSet' macro requires a raw type",
+					line: 1,
+					column: 1
+				)
+			],
+			macros: macros,
+			indentationWidth: .spaces(2)
+		)
+	}
+}
+#endif


### PR DESCRIPTION
This pull request introduces a new macro, `OptionSet`, to the QizhMacroKit library, enabling automatic synthesis of `OptionSet` conformance for structs with a nested `Options` enum. The macro implementation, plugin registration, usage example, and comprehensive tests are included. Additionally, the SwiftSyntax dependency is pinned to a branch compatible with Xcode 26.2 / Swift 6.2 to avoid toolchain resolution errors.

**OptionSet Macro Implementation and Integration**

* Added the `OptionSetGenerator` macro in `Sources/QizhMacroKitMacros/OptionSetGenerator.swift`, which synthesizes `OptionSet` conformance for structs with a nested options enum and a specified raw type. It includes diagnostic handling for common misuses such as missing struct or enum, and missing raw type.
* Registered the new macro in the plugin entry point by adding `OptionSetGenerator.self` to the list of compiler plugin macros in `Sources/QizhMacroKitMacros/_QizhMacroKitMacro.swift`.

**Macro Usage and Documentation**

* Documented and defined the `OptionSet` macro in `Sources/QizhMacroKit/OptionSet.swift`, with usage instructions and an example.
* Added a sample usage of the macro in `Sources/QizhMacroKitClient/OptionSet.swift` demonstrating how to apply the macro to a struct with a nested options enum.

**Testing and Validation**

* Introduced a suite of tests in `Tests/OptionSetTests/OptionSetMacroTests.swift` to validate macro expansion, correct code generation, and error diagnostics for various edge cases (e.g., missing struct, missing enum, missing raw type).

**Dependency Management**

* Updated the SwiftSyntax dependency in `Package.swift` to pin it to the `release/6.2` branch, matching Xcode 26.2 / Swift 6.2, to avoid `_SwiftSyntaxCShims` resolution errors.

**Other Minor Changes**

* Minor formatting fix in `Package.swift`

<details><summary>Previous PR Details (commit based)</summary>
<p>

- [x] Introduces the `OptionSet` macro for generating `OptionSet` conformances from structs with nested `Options` `enum`s.
- [x] Adds `OptionSetGenerator` macro implementation, usage example, and comprehensive tests for macro expansion and diagnostics.
  - Copied and slightly modified from Apple's examples.
- [x] Updates macro registration in `QizhMacroKitMacros` and refines `SwiftSyntax` dependency in `Package.swift`.

</p>
</details> 