### PR TITLE
`@CaseValue` macro update: Unique naming logic & Extensive edge case tests

### DIFF
--- a/Sources/QizhMacroKitMacros/CaseValueGenerator.swift
+++ b/Sources/QizhMacroKitMacros/CaseValueGenerator.swift
@@ -32,7 +32,7 @@ public struct CaseValueGenerator: MemberMacro {
 		
 		let members = enumDecl.memberBlock.members
 		var computedProperties: [DeclSyntax] = []
-		var proprtyNames: Set<String> = []
+		var propertyNames: Set<String> = []
 		
 		let allModifiers = enumDecl.modifiers.map(\.name.text)
 		let accessControlSet: Set<String> = ["open", "public", "package", "internal", "fileprivate", "private"]
@@ -40,7 +40,6 @@ public struct CaseValueGenerator: MemberMacro {
 		let modifiersString: String = accessModifiers.isEmpty
 			? ""
 			: accessModifiers.joined(separator: " ") + " "
-		
 		
 		for member in members {
 			guard let enumCaseDecl = member.decl.as(EnumCaseDeclSyntax.self) else {
@@ -162,7 +161,7 @@ public struct CaseValueGenerator: MemberMacro {
 						*/
 					}
 					
-					if proprtyNames.contains(propertyName) {
+					if propertyNames.contains(propertyName) {
 						let typeName = parameterTypeName
 							.replacing(/[^a-zA-Z0-9.]+/, with: "_")
 							.trimmingCharacters(in: CharacterSet(charactersIn: "_"))
@@ -170,11 +169,11 @@ public struct CaseValueGenerator: MemberMacro {
 						propertyName = "\(propertyName)_\(typeName)".toCamelCase
 					}
 					
-					if proprtyNames.contains(propertyName) {
+					if propertyNames.contains(propertyName) {
 						var number: UInt = 0
 						repeat {
 							number += 1
-						} while proprtyNames.contains("\(propertyName)\(number)")
+						} while propertyNames.contains("\(propertyName)\(number)")
 						propertyName += "\(number)"
 					}
 					
@@ -193,7 +192,7 @@ public struct CaseValueGenerator: MemberMacro {
 						"""
 					
 					computedProperties.append(addedProperty)
-					proprtyNames.insert(propertyName)
+					propertyNames.insert(propertyName)
 				}
 			}
 		}

--- a/Sources/QizhMacroKitMacros/CaseValueGenerator.swift
+++ b/Sources/QizhMacroKitMacros/CaseValueGenerator.swift
@@ -182,7 +182,7 @@ public struct CaseValueGenerator: MemberMacro {
 					let parametersList = parametersString(for: index, of: totalParameters)
 					
 					let addedProperty: DeclSyntax = """
-						/// `\(raw: parameterTypeName)` value of `\(raw: parameterName.text)` parameter in `.\(raw: caseNameText)` case 
+						/// `\(raw: parameterTypeName)` value of `\(raw: parameterName.text)` parameter in `.\(raw: caseNameText)` case.
 						\(raw: modifiersString)var \(raw: propertyName): \(raw: parameterTypeName) {
 							switch self {
 							case .\(raw: caseNameText)(\(raw: parametersList)): \(raw: Self.defaultValueName)

--- a/Sources/QizhMacroKitMacros/CaseValueGenerator.swift
+++ b/Sources/QizhMacroKitMacros/CaseValueGenerator.swift
@@ -9,6 +9,7 @@ import SwiftSyntax
 import SwiftDiagnostics
 import SwiftSyntaxMacros
 import SwiftSyntaxBuilder
+import Foundation
 
 public struct CaseValueGenerator: MemberMacro {
 	public static func expansion(
@@ -31,6 +32,7 @@ public struct CaseValueGenerator: MemberMacro {
 		
 		let members = enumDecl.memberBlock.members
 		var computedProperties: [DeclSyntax] = []
+		var proprtyNames: Set<String> = []
 		
 		let allModifiers = enumDecl.modifiers.map(\.name.text)
 		let accessControlSet: Set<String> = ["open", "public", "package", "internal", "fileprivate", "private"]
@@ -38,6 +40,7 @@ public struct CaseValueGenerator: MemberMacro {
 		let modifiersString: String = accessModifiers.isEmpty
 			? ""
 			: accessModifiers.joined(separator: " ") + " "
+		
 		
 		for member in members {
 			guard let enumCaseDecl = member.decl.as(EnumCaseDeclSyntax.self) else {
@@ -122,7 +125,7 @@ public struct CaseValueGenerator: MemberMacro {
 					
 					/// Use case name only when parameter name is the same
 					
-					let propertyName: String
+					var propertyName: String
 					if caseNameText.localizedLowercase == parameterName.text.localizedLowercase {
 						propertyName = caseNameText
 						
@@ -134,7 +137,19 @@ public struct CaseValueGenerator: MemberMacro {
 							)
 						)
 					} else {
-						propertyName = "\(caseNameText)\(parameterName.text)".toCamelCase
+						/// ## What's `_` for?
+						/// `_` is here to avoid cases where both `caseNameText` and
+						/// `parameterName.text` are lowercased.
+						/// ```swift
+						/// let wrong = ("foo" + "bar").toCamelCase
+						/// // wrong = "foobar".toCamelCase
+						/// // wrong = "foobar"
+						///
+						/// let correct = ("foo" + "_" + "bar").toCamelCase
+						/// // correct = "foo_bar".toCamelCase
+						/// // correct = "fooBar"
+						/// ```
+						propertyName = "\(caseNameText)_\(parameterName.text)".toCamelCase
 						
 						/*
 						context.diagnose(
@@ -147,11 +162,28 @@ public struct CaseValueGenerator: MemberMacro {
 						*/
 					}
 					
+					if proprtyNames.contains(propertyName) {
+						let typeName = parameterTypeName
+							.replacing(/[^a-zA-Z0-9.]+/, with: "_")
+							.trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+						
+						propertyName = "\(propertyName)_\(typeName)".toCamelCase
+					}
+					
+					if proprtyNames.contains(propertyName) {
+						var number: UInt = 0
+						repeat {
+							number += 1
+						} while proprtyNames.contains("\(propertyName)\(number)")
+						propertyName += "\(number)"
+					}
+					
 					/// Output generation
 					
 					let parametersList = parametersString(for: index, of: totalParameters)
 					
 					let addedProperty: DeclSyntax = """
+						/// `\(raw: parameterTypeName)` value of `\(raw: parameterName.text)` parameter in `.\(raw: caseNameText)` case 
 						\(raw: modifiersString)var \(raw: propertyName): \(raw: parameterTypeName) {
 							switch self {
 							case .\(raw: caseNameText)(\(raw: parametersList)): \(raw: Self.defaultValueName)
@@ -161,6 +193,7 @@ public struct CaseValueGenerator: MemberMacro {
 						"""
 					
 					computedProperties.append(addedProperty)
+					proprtyNames.insert(propertyName)
 				}
 			}
 		}

--- a/Tests/CaseValueTests/CaseValueMacroTests.swift
+++ b/Tests/CaseValueTests/CaseValueMacroTests.swift
@@ -17,5 +17,72 @@ struct CaseValueMacroTests {
 		#expect(word.int == nil)
 		#expect(word.textString == "hi")
 	}
+	
+	// MARK: Edge Cases
+	
+	@Suite("Edge cases")
+	struct EdgeCases {
+		/// Verifies that the `@CaseValue` macro generates property names in lower camel
+		/// case, normalizing varying original case styles in enum case and parameter
+		/// identifiers.
+		///
+		/// This test defines an enum with three stylistic variants of the same logical
+		/// case:
+		/// - `case foo(_ bar: Int)`
+		/// - `case FOO(_ BAR: String)`
+		/// - `case Foo(_ Bar: String?)`
+		///
+		/// It then asserts that the synthesized accessors:
+		/// - share a consistent lower-camel-case base prefix derived from the case name
+		///   (`foo`)
+		/// - incorporate the associated value label normalized to lower camel case (`Bar`)
+		/// - append unambiguous, type-informed suffixes when needed (e.g. `String`,
+		///   `String1`) to avoid naming collisions across overloads/optionality
+		///
+		/// ## Expectations
+		/// - `foo(bar: Int)` produces `fooBar` (`Int?`),
+		///   while string-based accessors are `nil`.
+		/// - `FOO(BAR: String)` produces `fooBarString` (`String?`),
+		///   while others are `nil`.
+		/// - `Foo(Bar: String?)` produces `fooBarString1` (`String??`),
+		///   while others are `nil`.
+		/// - Optional associated values propagate to optional accessor results,
+		///   ensuring `nil` when the case or its payload does not match.
+		///
+		/// Overall, the test ensures case/label normalization to lower camel case and
+		/// deterministic, collision-free naming for multiple associated-value variants.
+		@Test("Property names are in camel case")
+		func propertyNameIsInCamelCase() {
+			@CaseValue enum Em {
+				case foo(_ bar: Int)
+				case FOO(_ BAR: String)
+				case Foo(_ Bar: String?)
+			}
+			
+			let i: Int = 42
+			let s: String = "fourty two"
+			let v1 = Em.foo(i)
+			let v2 = Em.FOO(s)
+			let v3 = Em.Foo(s)
+			let v4 = Em.Foo(nil)
+			
+			#expect(v1.fooBar == i)
+			#expect(v1.fooBarString == nil)
+			#expect(v1.fooBarString1 == nil)
+			
+			#expect(v2.fooBar == nil)
+			#expect(v2.fooBarString == s)
+			#expect(v2.fooBarString1 == nil)
+			
+			#expect(v3.fooBar == nil)
+			#expect(v3.fooBarString == nil)
+			#expect(v3.fooBarString1 == s)
+			
+			#expect(v4.fooBar == nil)
+			#expect(v4.fooBarString == nil)
+			#expect(v4.fooBarString1 == nil)
+		}
+	}
 }
+
 #endif

--- a/Tests/CaseValueTests/CaseValueMacroTests.swift
+++ b/Tests/CaseValueTests/CaseValueMacroTests.swift
@@ -60,7 +60,7 @@ struct CaseValueMacroTests {
 			}
 			
 			let i: Int = 42
-			let s: String = "fourty two"
+			let s: String = "forty two"
 			let v1 = Em.foo(i)
 			let v2 = Em.FOO(s)
 			let v3 = Em.Foo(s)


### PR DESCRIPTION
This pull request improves the `@CaseValue` macro by making its generated property names more robust and collision-free, especially for enums with cases and parameter names that differ only by casing or type. It also adds comprehensive tests to verify the new naming logic and edge cases.

### Macro property naming improvements

* Ensures generated property names are consistently in lower camel case, even when enum case and parameter identifiers use different casing styles.
* Adds logic to avoid property name collisions by appending type-based suffixes and, if necessary, a numeric suffix for further disambiguation. This guarantees unique accessor names for each associated value.
* Tracks property names during generation to prevent duplicates and applies normalization and suffixing as needed. [[1]](diffhunk://#diff-0d475e6c98b38241ef4d926aa9cc0ad56bfa0309fb3cbb2f0df725eb33a76284R35) [[2]](diffhunk://#diff-0d475e6c98b38241ef4d926aa9cc0ad56bfa0309fb3cbb2f0df725eb33a76284R195)
* Documents the rationale for using underscores in property name generation to ensure proper camel case conversion.

### Testing enhancements

* Adds a new suite of edge case tests to confirm that the macro generates normalized, collision-free property names and handles optional associated values correctly.

### Miscellaneous

* Imports `Foundation` to support new string manipulation and normalization logic.

<details><summary><h4>Original PR Details</h4></summary>
<p>

- [x] Enhances the `CaseValueGenerator` to avoid property name collisions by appending type-based and numeric suffixes when necessary.
- [x] Updates tests to verify camel case normalization and collision-free property naming for enum cases with similar names and associated values.

</p>
</details> 