### PR TITLE
Expand test coverage to `99%`✨ with edge case tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ DerivedData/
 .netrc
 DerivedData-filetree.md
 Package.resolved
+.vscode/settings.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ QizhMacroKit/
 | `@IsNotCase` | Generates boolean `isNot<CaseName>` properties for enum cases |
 | `@OptionSet<RawType>` | Creates an `OptionSet` from a struct containing a nested `Options` enum |
 | `#stringify` | Converts expressions to their string representation |
+| `#dictionarify` | Returns a dictionary element mapping the expression source text to its evaluated value |
 
 ## Build and Test Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,20 @@ For each major repository component:
 - Generate and post a report
 - Update the PR description with the results
 
+### PR Description Updates
+
+When making significant changes to a PR description, preserve the previous content:
+
+```markdown
+<details><summary><h3>Previously in this PR</h3></summary>
+
+<!-- Previous PR description here -->
+
+</details>
+```
+
+Wrapping depth is unlimited — nest as needed for multiple major updates.
+
 ### Auto-Commit Policy
 
 Automatically commit changes (with a generated commit title and description) when **ALL** of the following conditions are met:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,177 @@
+# AGENTS.md – QizhMacroKit
+
+## Agent Personality
+
+- 70% Professional
+- 20% Sarcastic
+- 10% Self-ironic
+- 0% Forgetful & refusing
+
+---
+
+## Project Overview
+
+QizhMacroKit is a Swift package providing a collection of Swift macros for enhanced enum handling, option sets, and code generation. It uses Swift Macros (introduced in Swift 5.9) powered by SwiftSyntax to generate compile-time code.
+
+## Project Structure
+
+```
+QizhMacroKit/
+├── Sources/
+│   ├── QizhMacroKit/             # Public API – macro declarations
+│   ├── QizhMacroKitMacros/       # Macro implementations (SwiftSyntax-based)
+│   │   └── Helpers/              # Utility extensions for string manipulation
+│   └── QizhMacroKitClient/       # Example client executable
+├── Tests/
+│   ├── CaseNameTests/
+│   ├── CaseValueTests/
+│   ├── IsCaseTests/
+│   ├── IsNotCaseTests/
+│   ├── OptionSetTests/
+│   └── StringifyTests/
+├── Docs/                         # Per-macro documentation (.md files)
+├── TestPlans/                    # Xcode test plans
+├── Package.swift                 # Swift Package Manager manifest
+├── README.md
+├── TODO.md
+├── KNOWN_ISSUES.md
+└── .github/
+    └── workflows/                # CI/CD workflows
+```
+
+## Key Technologies
+
+- **Swift 6.2** with Swift 6 language mode
+- **Swift Package Manager** for dependency management
+- **SwiftSyntax 602.0.0+** for macro implementation
+- **Swift Testing** framework for unit tests
+- Supported platforms: iOS 17+, macOS 14+, Mac Catalyst 17+
+
+## Available Macros
+
+| Macro | Description |
+|-------|-------------|
+| `@CaseName` | Generates a `caseName` property returning the enum case name as a String |
+| `@CaseValue` | Generates value extraction for enum cases with associated values |
+| `@IsCase` | Generates boolean `is<CaseName>` properties for enum cases |
+| `@IsNotCase` | Generates boolean `isNot<CaseName>` properties for enum cases |
+| `@OptionSet<RawType>` | Creates an `OptionSet` from a struct containing a nested `Options` enum |
+| `#stringify` | Converts expressions to their string representation |
+
+## Build and Test Commands
+
+```bash
+# Build the package
+swift build
+
+# Build in debug configuration
+swift build --configuration debug
+
+# Run all tests
+swift test
+
+# Run tests in parallel with verbose output
+swift test --parallel --verbose
+```
+
+---
+
+## Coding Conventions
+
+### General Style
+
+- Use **tabs** for indentation
+- Follow Swift API Design Guidelines
+- Keep macro implementations focused and single-purpose
+- Use descriptive variable names
+- Include file headers with copyright info
+
+### File Organization
+
+- Each macro has a corresponding generator file in `Sources/QizhMacroKitMacros/`
+- Public macro declarations go in `Sources/QizhMacroKit/`
+- Helper utilities go in `Sources/QizhMacroKitMacros/Helpers/`
+- Tests are organized by macro in `Tests/<MacroName>Tests/`
+- Per-macro documentation in `Docs/<MacroName>.md`
+
+### Macro Implementation Pattern
+
+When implementing a new macro:
+
+1. Create the public declaration in `Sources/QizhMacroKit/<MacroName>.swift`
+2. Create the generator in `Sources/QizhMacroKitMacros/<MacroName>Generator.swift`
+3. Register the generator in `_QizhMacroKitMacro.swift`
+4. Add tests in `Tests/<MacroName>Tests/`
+5. Add documentation in `Docs/<MacroName>.md`
+
+### Error Handling
+
+- Use `QizhMacroGeneratorDiagnostic` for macro-specific errors
+- Provide clear, actionable error messages
+- Validate input declarations before processing
+
+### Testing
+
+- Use Swift Testing framework (`@Test`, `@Suite`, `#expect`)
+- Wrap tests in `#if os(macOS)` since macros require macOS
+- Test both success cases and error conditions
+- Use `SwiftSyntaxMacrosTestSupport` for macro expansion testing
+
+---
+
+## Agent Responsibilities
+
+### Code Generation
+
+- Generate Swift 6.2+ code upon request
+- Generate SwiftUI code upon request
+- Review code written by others
+- Find & fix potential bugs & issues
+- Suggest improvements
+
+### Dependency Management
+
+- Check dependency versions and update them if needed
+
+**IMPORTANT:**
+- Never update a dependency to a version which introduces breaking changes for entities used in this repository without getting explicit confirmation
+  - Instead: Update to the latest dependency version with no breaking changes
+- If you can auto-update the code to adopt a dependency's breaking change – ask the author for confirmation first
+  - Otherwise: Create a corresponding Issue for the dependency update adoption when possible and mention it in your report
+
+### Documentation
+
+For all added or updated code entities:
+- Generate or update documentation following DocC best practices
+- Generate or update tests
+
+For each major repository component:
+- Generate or update `Docs/<ComponentName>.md` documentation files following GitHub documentation best practices
+- Update the main `README.md` file
+  - Add or update references to all component documentation files
+
+### Before Finishing
+
+- Build all targets with Swift 6.2+ compiler to ensure no errors
+- Run all tests to ensure none fail
+- Generate and post a report
+- Update the PR description with the results
+
+---
+
+## Dependencies
+
+- **swift-syntax** (602.0.0+): Required for macro implementation
+  - SwiftSyntax
+  - SwiftSyntaxMacros
+  - SwiftCompilerPlugin
+  - SwiftSyntaxBuilder
+  - SwiftDiagnostics
+  - SwiftSyntaxMacrosTestSupport (for tests)
+
+## CI/CD
+
+The repository uses GitHub Actions for continuous integration:
+- Builds run on `macos-latest`
+- Uses Swift 6.2 toolchain
+- Runs on push to `main` and pull requests targeting `main`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@ QizhMacroKit/
 ├── Tests/
 │   ├── CaseNameTests/
 │   ├── CaseValueTests/
+│   ├── DiagnosticTests/
+│   ├── HelperTests/
 │   ├── IsCaseTests/
 │   ├── IsNotCaseTests/
 │   ├── OptionSetTests/
@@ -156,6 +158,29 @@ For each major repository component:
 - Run all tests to ensure none fail
 - Generate and post a report
 - Update the PR description with the results
+
+### Auto-Commit Policy
+
+Automatically commit changes (with a generated commit title and description) when **ALL** of the following conditions are met:
+
+1. **Task successfully finished** — The requested work is complete
+2. **Code is documented** — All added/updated code has proper documentation
+3. **Code is tested** — All added/updated code is covered by tests
+4. **Tests pass** — All tests run successfully (`swift test` exits with code 0)
+5. **Documentation updated** — Relevant `.md` files are updated (README, Docs/, KNOWN_ISSUES, etc.)
+
+Commit message format:
+```
+<concise title summarizing the change>
+
+<detailed description of what was changed and why>
+
+## Changes
+- List of specific changes made
+
+## Testing
+- Summary of test results
+```
 
 ---
 

--- a/Docs/CaseValue.md
+++ b/Docs/CaseValue.md
@@ -1,12 +1,14 @@
 # CaseValue Macro
 
-> Last Updated: November 25, 2025
+> Last Updated: December 18, 2025
 
 An attached member macro that generates computed properties to extract associated values from enum cases.
 
 ## Overview
 
-The `@CaseValue` macro automatically generates optional computed properties for each associated value in your enum cases. This eliminates boilerplate code when you need to access specific values from enum cases.
+The `@CaseValue` macro automatically generates computed properties for each associated value in your enum cases. This eliminates boilerplate code when you need to access specific values from enum cases.
+
+**For single-case enums**, the generated properties are **non-optional** since there's only one possible case. **For multi-case enums**, the properties are optional and return `nil` when the current case doesn't match.
 
 ## Declaration
 
@@ -112,6 +114,34 @@ enum Callback {
 // Generated: onSelectCallback: (() -> Void)?
 ```
 
+### Single-Case Enums
+
+When an enum has only one case with associated values, the generated properties are **non-optional**. This avoids the "Default will never be executed" compiler warning:
+
+```swift
+@CaseValue
+enum Handler {
+    case action(handler: () -> Void)
+}
+
+// Generated: actionHandler: (() -> Void)  // Non-optional!
+
+let h = Handler.action { print("Hello") }
+h.actionHandler()  // Direct call, no unwrapping needed
+```
+
+Compare with a multi-case enum:
+
+```swift
+@CaseValue
+enum Event {
+    case tap(at: CGPoint)
+    case swipe(direction: String)
+}
+
+// Generated: tapAt: CGPoint?, swipeDirection: String?  // Optional
+```
+
 ## Access Modifiers
 
 The generated properties inherit the access level of the enum:
@@ -164,6 +194,11 @@ if let progress = result.loadingProgress {
 - Only works with enums (applying to other types produces a compile-time error)
 - Cases without associated values are skipped (no property generated)
 - Reserved Swift keywords as case names must be escaped with backticks
+
+## Notes
+
+- Single-case enums generate non-optional properties (no `default: nil` branch)
+- Multi-case enums generate optional properties with a `default: nil` fallback
 
 ## See Also
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,6 +1,6 @@
 # Known Issues
 
-> Last Updated: November 27, 2025
+> Last Updated: December 18, 2025
 
 This document lists known limitations and issues in QizhMacroKit.
 
@@ -84,6 +84,23 @@ The `escapedSwiftIdentifier` helper recognizes most common Swift keywords, but m
 - Attributes that can be used as identifiers
 
 **Workaround**: When using case names that cause issues, explicitly escape them with backticks in your source code.
+
+---
+
+### Test Coverage Limitations
+
+#### Untestable Code Paths
+
+**Status**: By Design  
+**Affected**: `_QizhMacroKitMacro.swift`
+
+The macro plugin entry point (`_QizhMacroKitMacro.swift`) registers macros with the Swift compiler via the `CompilerPlugin` protocol. This code:
+
+- Is invoked by the Swift compiler during compilation, not at runtime
+- Cannot be directly tested via unit tests
+- Appears as 0% coverage in code coverage reports
+
+This is expected behavior for Swift macro plugins. The actual macro implementations (generators) are fully testable and covered.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -183,11 +183,20 @@ QizhMacroKit/
 │   ├── QizhMacroKitMacros/     # Macro implementations (SwiftSyntax)
 │   │   └── Helpers/            # String manipulation utilities
 │   └── QizhMacroKitClient/     # Example usage
-├── Tests/                      # Test suites
+├── Tests/
+│   ├── CaseNameTests/          # @CaseName macro tests
+│   ├── CaseValueTests/         # @CaseValue macro tests
+│   ├── IsCaseTests/            # @IsCase macro tests
+│   ├── IsNotCaseTests/         # @IsNotCase macro tests
+│   ├── OptionSetTests/         # @OptionSet macro tests
+│   ├── StringifyTests/         # #stringify / #dictionarify tests
+│   ├── DiagnosticTests/        # Diagnostic types tests
+│   └── HelperTests/            # String helper extension tests
 ├── Docs/                       # Documentation
 ├── Package.swift               # SPM manifest
 ├── KNOWN_ISSUES.md             # Current limitations
 ├── TODO.md                     # Roadmap
+├── AGENTS.md                   # Agent instructions
 └── README.md                   # This file
 ```
 

--- a/Sources/QizhMacroKitMacros/CaseValueGenerator.swift
+++ b/Sources/QizhMacroKitMacros/CaseValueGenerator.swift
@@ -34,6 +34,14 @@ public struct CaseValueGenerator: MemberMacro {
 		var computedProperties: [DeclSyntax] = []
 		var propertyNames: Set<String> = []
 		
+		/// Count total enum cases to determine if we need optional types
+		/// Single-case enums get non-optional properties; multi-case enums get optional
+		let totalEnumCases = members
+			.compactMap { $0.decl.as(EnumCaseDeclSyntax.self) }
+			.flatMap(\.elements)
+			.count
+		let isSingleCaseEnum = totalEnumCases == 1
+		
 		let allModifiers = enumDecl.modifiers.map(\.name.text)
 		let accessControlSet: Set<String> = ["open", "public", "package", "internal", "fileprivate", "private"]
 		let accessModifiers = allModifiers.filter { accessControlSet.contains($0) }
@@ -97,12 +105,13 @@ public struct CaseValueGenerator: MemberMacro {
 						}
 					}
 					
-					/// Make output parameter `Optional`
+					/// Make output parameter `Optional` (unless single-case enum)
 					
 					var parameterTypeName: String = originalType.description
 						.trimmingCharacters(in: .whitespacesAndNewlines)
 					
-					if originalType.as(FunctionTypeSyntax.self) != nil {
+					let isFunctionType = originalType.as(FunctionTypeSyntax.self) != nil
+					if isFunctionType {
 						context.diagnose(
 							.note(
 								node: Syntax(node),
@@ -118,7 +127,10 @@ public struct CaseValueGenerator: MemberMacro {
 						originalType.as(OptionalTypeSyntax.self) != nil
 					|| 	originalType.as(IdentifierTypeSyntax.self)?.name.text == "Optional"
 					
-					if !isParameterOptional {
+					/// For single-case enums, keep the original type (non-optional)
+					/// For multi-case enums, wrap in Optional unless already optional
+					let useOptionalType = !isSingleCaseEnum && !isParameterOptional
+					if useOptionalType {
 						parameterTypeName = "\(parameterTypeName)?"
 					}
 					
@@ -181,15 +193,29 @@ public struct CaseValueGenerator: MemberMacro {
 					
 					let parametersList = parametersString(for: index, of: totalParameters)
 					
-					let addedProperty: DeclSyntax = """
-						/// `\(raw: parameterTypeName)` value of `\(raw: parameterName.text)` parameter in `.\(raw: caseNameText)` case.
-						\(raw: modifiersString)var \(raw: propertyName): \(raw: parameterTypeName) {
-							switch self {
-							case .\(raw: caseNameText)(\(raw: parametersList)): \(raw: Self.defaultValueName)
-							default: nil
+					let addedProperty: DeclSyntax
+					if isSingleCaseEnum {
+						/// Single-case enum: non-optional property, no default case
+						addedProperty = """
+							/// `\(raw: parameterTypeName)` value of `\(raw: parameterName.text)` parameter in `.\(raw: caseNameText)` case.
+							\(raw: modifiersString)var \(raw: propertyName): \(raw: parameterTypeName) {
+								switch self {
+								case .\(raw: caseNameText)(\(raw: parametersList)): \(raw: Self.defaultValueName)
+								}
 							}
-						}
-						"""
+							"""
+					} else {
+						/// Multi-case enum: optional property with default case
+						addedProperty = """
+							/// `\(raw: parameterTypeName)` value of `\(raw: parameterName.text)` parameter in `.\(raw: caseNameText)` case.
+							\(raw: modifiersString)var \(raw: propertyName): \(raw: parameterTypeName) {
+								switch self {
+								case .\(raw: caseNameText)(\(raw: parametersList)): \(raw: Self.defaultValueName)
+								default: nil
+								}
+							}
+							"""
+					}
 					
 					computedProperties.append(addedProperty)
 					propertyNames.insert(propertyName)

--- a/Sources/QizhMacroKitMacros/IsCasesGenerator.swift
+++ b/Sources/QizhMacroKitMacros/IsCasesGenerator.swift
@@ -33,7 +33,7 @@ public struct IsCasesGenerator: MemberMacro {
 		}
 		
 		let members = enumDecl.memberBlock.members
-        // Collect all enum case elements across all case declarations
+        /// Collect all enum case elements across all case declarations
         let caseDecls = members.compactMap { $0.decl.as(EnumCaseDeclSyntax.self) }
         let allCaseElements: [EnumCaseElementSyntax] = caseDecls.flatMap { Array($0.elements) }
 		var additions: [DeclSyntax] = []
@@ -56,7 +56,7 @@ public struct IsCasesGenerator: MemberMacro {
 			)
 			return []
 		} else if allCaseElements.count == 1 {
-			// Exactly one case element across the entire enum
+			/// Exactly one case element across the entire enum
 			let element = allCaseElements[0]
 			let caseName = element.name.text.withBackticksTrimmed
 			caseNames.append(caseName)
@@ -71,7 +71,7 @@ public struct IsCasesGenerator: MemberMacro {
 				"""
 			additions.append(property)
 		} else {
-			// Iterate over each collected case element
+			/// Iterate over each collected case element
 			for element in allCaseElements {
 				let caseName = element.name.text.withBackticksTrimmed
 				caseNames.append(caseName)
@@ -91,9 +91,9 @@ public struct IsCasesGenerator: MemberMacro {
 			}
 		}
 		
-		// Generate Cases enum
+		/// Generate Cases enum
 		let casesLines = caseNames
-			.map { "        case \($0.escapedSwiftIdentifier)" }
+			.map { "\t\tcase \($0.escapedSwiftIdentifier)" }
 			.joined(separator: "\n")
 		let casesDecl: DeclSyntax = """
 			/// A parameterless representation of `\(raw: enumDecl.name.text)` cases.
@@ -102,11 +102,11 @@ public struct IsCasesGenerator: MemberMacro {
 			}
 			"""
 		
-		// Property converting self to Cases
+		/// Property converting self to Cases
 		let mappingLines = caseNames
 			.map { name in
 				let escaped = name.escapedSwiftIdentifier
-				return "        case .\(escaped): .\(escaped)"
+				return "\t\tcase .\(escaped): .\(escaped)"
 			}
 			.joined(separator: "\n")
 		let caseValueProperty: DeclSyntax = """
@@ -118,7 +118,7 @@ public struct IsCasesGenerator: MemberMacro {
 			}
 			"""
 		
-		// Methods for checking membership
+		/// Methods for checking membership
 		let arrayMethod: DeclSyntax = """
 			/// Returns `true` if `self` matches any case in `cases`.
 			/// - Parameter cases: An array of cases to match against.

--- a/Sources/QizhMacroKitMacros/OptionSetGenerator.swift
+++ b/Sources/QizhMacroKitMacros/OptionSetGenerator.swift
@@ -45,6 +45,8 @@ extension OptionSetMacroDiagnostic: DiagnosticMessage {
 
 	var severity: DiagnosticSeverity { .error }
 
+	/// Required by `DiagnosticMessage` protocol.
+	/// Coverage note: Called indirectly via `diagnose(at:)`, not directly testable.
 	var diagnosticID: MessageID {
 		MessageID(domain: "Swift", id: "OptionSet.\(self)")
 	}
@@ -65,7 +67,7 @@ extension LabeledExprListSyntax {
 			if let label = element.label, label.text == name {
 				return true
 			}
-
+			/// ✨ Line 69: Nice. ✨
 			return false
 		}
 	}

--- a/Sources/QizhMacroKitMacros/OptionSetGenerator.swift
+++ b/Sources/QizhMacroKitMacros/OptionSetGenerator.swift
@@ -17,8 +17,8 @@ import SwiftSyntaxMacros
 
 enum OptionSetMacroDiagnostic {
 	case requiresStruct
-	case requiresStringLiteral(String)
-	case requiresOptionsEnum(String)
+	case requiresStringLiteral(_ name: String)
+	case requiresOptionsEnum(_ name: String)
 	case requiresOptionsEnumRawType
 }
 
@@ -29,17 +29,10 @@ extension OptionSetMacroDiagnostic: DiagnosticMessage {
 
 	var message: String {
 		switch self {
-		case .requiresStruct:
-			return "'OptionSet' macro can only be applied to a struct"
-
-		case .requiresStringLiteral(let name):
-			return "'OptionSet' macro argument \(name) must be a string literal"
-
-		case .requiresOptionsEnum(let name):
-			return "'OptionSet' macro requires nested options enum '\(name)'"
-
-		case .requiresOptionsEnumRawType:
-			return "'OptionSet' macro requires a raw type"
+		case .requiresStruct: 					"'OptionSet' macro can only be applied to a struct"
+		case .requiresStringLiteral(let name): 	"'OptionSet' macro argument '\(name)' must be a string literal"
+		case .requiresOptionsEnum(let name): 	"'OptionSet' macro requires nested options enum '\(name)'"
+		case .requiresOptionsEnumRawType: 		"'OptionSet' macro requires a raw type"
 		}
 	}
 
@@ -52,32 +45,34 @@ extension OptionSetMacroDiagnostic: DiagnosticMessage {
 	}
 }
 
-/// The label used for the OptionSet macro argument that provides the name of
-/// the nested options enum.
+/// The label used for the OptionSet macro argument
+/// that provides the name of the nested options enum.
 private let optionsEnumNameArgumentLabel = "optionsName"
 
-/// The default name used for the nested "Options" enum. This should
-/// eventually be overridable.
+/// The default name used for the nested "Options" enum.
+/// This should eventually be overridable.
 private let defaultOptionsEnumName = "Options"
 
 extension LabeledExprListSyntax {
 	/// Retrieve the first element with the given label.
 	func first(labeled name: String) -> Element? {
-		return first { element in
-			if let label = element.label, label.text == name {
-				return true
+		first { element in
+			if let label = element.label {
+				label.text == name
+			} else {
+				false
 			}
-			/// ✨ Line 69: Nice. ✨
-			return false
 		}
 	}
 }
 
+/// ✨ Line 69: Nice. ✨
+
+/// `@OptionSet` macro generator
 public struct OptionSetGenerator {
 	/// Decodes the arguments to the macro expansion.
-	///
 	/// - Returns: the important arguments used by the various roles of this
-	/// macro inhabits, or nil if an error occurred.
+	///   macro inhabits, or nil if an error occurred.
 	static func decodeExpansion(
 		of attribute: AttributeSyntax,
 		attachedTo decl: some DeclGroupSyntax,
@@ -87,18 +82,16 @@ public struct OptionSetGenerator {
 		/// Determine the name of the options enum.
 		let optionsEnumName: String
 		if case let .argumentList(arguments) = attribute.arguments,
-			let optionEnumNameArg = arguments.first(labeled: optionsEnumNameArgumentLabel)
-		{
+		   let optionEnumNameArg = arguments.first(labeled: optionsEnumNameArgumentLabel) {
 			/// We have a options name; make sure it is a string literal.
 			guard let stringLiteral = optionEnumNameArg.expression.as(StringLiteralExprSyntax.self),
-				stringLiteral.segments.count == 1,
-				case let .stringSegment(optionsEnumNameString)? = stringLiteral.segments.first
+				  stringLiteral.segments.count == 1,
+				  case let .stringSegment(optionsEnumNameString)? = stringLiteral.segments.first
 			else {
 				if emitDiagnostics {
 					context.diagnose(
-						OptionSetMacroDiagnostic.requiresStringLiteral(optionsEnumNameArgumentLabel).diagnose(
-							at: optionEnumNameArg.expression
-						)
+						OptionSetMacroDiagnostic.requiresStringLiteral(optionsEnumNameArgumentLabel)
+							.diagnose(at: optionEnumNameArg.expression)
 					)
 				}
 				return nil
@@ -118,33 +111,35 @@ public struct OptionSetGenerator {
 		}
 
 		/// Find the option enum within the struct.
-		guard
-			let optionsEnum = decl.memberBlock.members.compactMap({ member in
-				if let enumDecl = member.decl.as(EnumDeclSyntax.self),
-					enumDecl.name.text == optionsEnumName
-				{
-					return enumDecl
-				}
-
-				return nil
-			}).first
-		else {
+		guard let optionsEnum = decl.memberBlock.members.compactMap({ member in
+			if let enumDecl = member.decl.as(EnumDeclSyntax.self),
+			   enumDecl.name.text == optionsEnumName {
+				enumDecl
+			} else {
+				nil
+			}
+		}).first else {
 			if emitDiagnostics {
-				context.diagnose(OptionSetMacroDiagnostic.requiresOptionsEnum(optionsEnumName).diagnose(at: decl))
+				context.diagnose(
+					OptionSetMacroDiagnostic.requiresOptionsEnum(optionsEnumName).diagnose(at: decl)
+				)
 			}
 			return nil
 		}
 
 		/// Retrieve the raw type from the attribute.
-		guard let genericArgs = attribute.attributeName.as(IdentifierTypeSyntax.self)?.genericArgumentClause,
-			let rawType = genericArgs.arguments.first?.argument
+		guard let genericArgs = attribute.attributeName.as(IdentifierTypeSyntax.self)?
+													   .genericArgumentClause,
+			  let rawType = genericArgs.arguments.first?.argument
 		else {
 			if emitDiagnostics {
-				context.diagnose(OptionSetMacroDiagnostic.requiresOptionsEnumRawType.diagnose(at: attribute))
+				context.diagnose(
+					OptionSetMacroDiagnostic.requiresOptionsEnumRawType.diagnose(at: attribute)
+				)
 			}
 			return nil
 		}
-
+		
 		return (structDecl, optionsEnum, rawType)
 	}
 }
@@ -158,19 +153,23 @@ extension OptionSetGenerator: ExtensionMacro {
 		in context: some MacroExpansionContext
 	) throws -> [ExtensionDeclSyntax] {
 		/// Decode the expansion arguments.
-		guard
-			let (structDecl, _, _) = decodeExpansion(of: node, attachedTo: declaration, in: context, emitDiagnostics: false)
-		else {
+		guard let (structDecl, _, _) = decodeExpansion(
+			of: node,
+			attachedTo: declaration,
+			in: context,
+			emitDiagnostics: false
+		) else {
 			return []
 		}
-
+		
 		/// If there is an explicit conformance to OptionSet already, don't add one.
 		if let inheritedTypes = structDecl.inheritanceClause?.inheritedTypes,
-			inheritedTypes.contains(where: { inherited in inherited.type.trimmedDescription == "OptionSet" })
-		{
+		   inheritedTypes.contains(where: { inherited in
+			   inherited.type.trimmedDescription == "OptionSet"
+		   }) {
 			return []
 		}
-
+		
 		return [try ExtensionDeclSyntax("extension \(type): OptionSet {}")]
 	}
 }
@@ -183,25 +182,24 @@ extension OptionSetGenerator: MemberMacro {
 		in context: some MacroExpansionContext
 	) throws -> [DeclSyntax] {
 		/// Decode the expansion arguments.
-		guard
-			let (_, optionsEnum, rawType) = decodeExpansion(
-				of: attribute,
-				attachedTo: decl,
-				in: context,
-				emitDiagnostics: true
-			)
-		else {
+		guard let (_, optionsEnum, rawType) = decodeExpansion(
+			of: attribute,
+			attachedTo: decl,
+			in: context,
+			emitDiagnostics: true
+		) else {
 			return []
 		}
 
 		/// Find all of the case elements.
-		let caseElements: [EnumCaseElementSyntax] = optionsEnum.memberBlock.members.flatMap { member in
-			guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else {
-				return [EnumCaseElementSyntax]()
-			}
+		let caseElements: [EnumCaseElementSyntax] = optionsEnum.memberBlock.members
+			.flatMap { member in
+				guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else {
+					return [EnumCaseElementSyntax]()
+				}
 
-			return Array(caseDecl.elements)
-		}
+				return Array(caseDecl.elements)
+			}
 
 		/// Dig out the access control keyword we need.
 		let access = decl.modifiers.first(where: \.isNeededAccessLevelModifier)
@@ -225,8 +223,8 @@ extension OptionSetGenerator: MemberMacro {
 extension DeclModifierSyntax {
 	var isNeededAccessLevelModifier: Bool {
 		switch self.name.tokenKind {
-		case .keyword(.public): return true
-		default: return false
+		case .keyword(.public): true
+		default: 				false
 		}
 	}
 }

--- a/Sources/QizhMacroKitMacros/OptionSetGenerator.swift
+++ b/Sources/QizhMacroKitMacros/OptionSetGenerator.swift
@@ -82,12 +82,12 @@ public struct OptionSetGenerator {
 		in context: some MacroExpansionContext,
 		emitDiagnostics: Bool
 	) -> (StructDeclSyntax, EnumDeclSyntax, GenericArgumentSyntax.Argument)? {
-		// Determine the name of the options enum.
+		/// Determine the name of the options enum.
 		let optionsEnumName: String
 		if case let .argumentList(arguments) = attribute.arguments,
 			let optionEnumNameArg = arguments.first(labeled: optionsEnumNameArgumentLabel)
 		{
-			// We have a options name; make sure it is a string literal.
+			/// We have a options name; make sure it is a string literal.
 			guard let stringLiteral = optionEnumNameArg.expression.as(StringLiteralExprSyntax.self),
 				stringLiteral.segments.count == 1,
 				case let .stringSegment(optionsEnumNameString)? = stringLiteral.segments.first
@@ -107,7 +107,7 @@ public struct OptionSetGenerator {
 			optionsEnumName = defaultOptionsEnumName
 		}
 
-		// Only apply to structs.
+		/// Only apply to structs.
 		guard let structDecl = decl.as(StructDeclSyntax.self) else {
 			if emitDiagnostics {
 				context.diagnose(OptionSetMacroDiagnostic.requiresStruct.diagnose(at: decl))
@@ -115,7 +115,7 @@ public struct OptionSetGenerator {
 			return nil
 		}
 
-		// Find the option enum within the struct.
+		/// Find the option enum within the struct.
 		guard
 			let optionsEnum = decl.memberBlock.members.compactMap({ member in
 				if let enumDecl = member.decl.as(EnumDeclSyntax.self),
@@ -133,7 +133,7 @@ public struct OptionSetGenerator {
 			return nil
 		}
 
-		// Retrieve the raw type from the attribute.
+		/// Retrieve the raw type from the attribute.
 		guard let genericArgs = attribute.attributeName.as(IdentifierTypeSyntax.self)?.genericArgumentClause,
 			let rawType = genericArgs.arguments.first?.argument
 		else {
@@ -155,14 +155,14 @@ extension OptionSetGenerator: ExtensionMacro {
 		conformingTo protocols: [TypeSyntax],
 		in context: some MacroExpansionContext
 	) throws -> [ExtensionDeclSyntax] {
-		// Decode the expansion arguments.
+		/// Decode the expansion arguments.
 		guard
 			let (structDecl, _, _) = decodeExpansion(of: node, attachedTo: declaration, in: context, emitDiagnostics: false)
 		else {
 			return []
 		}
 
-		// If there is an explicit conformance to OptionSet already, don't add one.
+		/// If there is an explicit conformance to OptionSet already, don't add one.
 		if let inheritedTypes = structDecl.inheritanceClause?.inheritedTypes,
 			inheritedTypes.contains(where: { inherited in inherited.type.trimmedDescription == "OptionSet" })
 		{
@@ -180,7 +180,7 @@ extension OptionSetGenerator: MemberMacro {
 		conformingTo: [TypeSyntax],
 		in context: some MacroExpansionContext
 	) throws -> [DeclSyntax] {
-		// Decode the expansion arguments.
+		/// Decode the expansion arguments.
 		guard
 			let (_, optionsEnum, rawType) = decodeExpansion(
 				of: attribute,
@@ -192,7 +192,7 @@ extension OptionSetGenerator: MemberMacro {
 			return []
 		}
 
-		// Find all of the case elements.
+		/// Find all of the case elements.
 		let caseElements: [EnumCaseElementSyntax] = optionsEnum.memberBlock.members.flatMap { member in
 			guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else {
 				return [EnumCaseElementSyntax]()
@@ -201,7 +201,7 @@ extension OptionSetGenerator: MemberMacro {
 			return Array(caseDecl.elements)
 		}
 
-		// Dig out the access control keyword we need.
+		/// Dig out the access control keyword we need.
 		let access = decl.modifiers.first(where: \.isNeededAccessLevelModifier)
 
 		let staticVars = caseElements.map { (element) -> DeclSyntax in

--- a/Sources/QizhMacroKitMacros/OptionSetGenerator.swift
+++ b/Sources/QizhMacroKitMacros/OptionSetGenerator.swift
@@ -83,7 +83,7 @@ public struct OptionSetGenerator {
 		let optionsEnumName: String
 		if case let .argumentList(arguments) = attribute.arguments,
 		   let optionEnumNameArg = arguments.first(labeled: optionsEnumNameArgumentLabel) {
-			/// We have a options name; make sure it is a string literal.
+			/// We have an options name; make sure it is a string literal.
 			guard let stringLiteral = optionEnumNameArg.expression.as(StringLiteralExprSyntax.self),
 				  stringLiteral.segments.count == 1,
 				  case let .stringSegment(optionsEnumNameString)? = stringLiteral.segments.first

--- a/Sources/QizhMacroKitMacros/StringifyGenerator.swift
+++ b/Sources/QizhMacroKitMacros/StringifyGenerator.swift
@@ -8,9 +8,6 @@
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftDiagnostics
-#if canImport(SwiftCompilerPlugin)
-import SwiftCompilerPlugin
-#endif
 
 // MARK: Stringify
 

--- a/Sources/QizhMacroKitMacros/StringifyGenerator.swift
+++ b/Sources/QizhMacroKitMacros/StringifyGenerator.swift
@@ -7,8 +7,10 @@
 
 import SwiftSyntax
 import SwiftSyntaxBuilder
-import SwiftCompilerPlugin
 import SwiftDiagnostics
+#if canImport(SwiftCompilerPlugin)
+import SwiftCompilerPlugin
+#endif
 
 // MARK: Stringify
 

--- a/TestPlans/MacrosTestPlan.xctestplan
+++ b/TestPlans/MacrosTestPlan.xctestplan
@@ -9,6 +9,8 @@
     }
   ],
   "defaultOptions" : {
+    "language" : "en",
+    "region" : "US",
     "targetForVariableExpansion" : {
       "containerPath" : "container:",
       "identifier" : "QizhMacroKitTests",

--- a/Tests/CaseNameTests/CaseNameMacroTests.swift
+++ b/Tests/CaseNameTests/CaseNameMacroTests.swift
@@ -174,5 +174,39 @@ struct CaseNameMacroTests {
 			macros: macros
 		)
 	}
+	
+	/// Tests that non-case members are skipped.
+	@Test("Skips non-case members in enum")
+	func skipsNonCaseMembers() {
+		assertMacroExpansion(
+			"""
+			@CaseName
+			enum Mixed {
+				case first
+				var computed: Int { 0 }
+				case second
+				func method() {}
+			}
+			""",
+			expandedSource: """
+			enum Mixed {
+				case first
+				var computed: Int { 0 }
+				case second
+				func method() {}
+			
+				var caseName: String {
+					switch self {
+					case .first:
+						"first"
+					case .second:
+						"second"
+					}
+				}
+			}
+			""",
+			macros: macros
+		)
+	}
 }
 #endif

--- a/Tests/CaseNameTests/CaseNameMacroTests.swift
+++ b/Tests/CaseNameTests/CaseNameMacroTests.swift
@@ -1,17 +1,178 @@
 #if os(macOS)
 import Testing
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
 @testable import QizhMacroKit
 @testable import QizhMacroKitMacros
 
 /// Tests for the `CaseName` macro.
 @Suite("CaseName macro")
 struct CaseNameMacroTests {
+	private let macros: [String: any Macro.Type] = [
+		"CaseName": CaseNameGenerator.self
+	]
+	
+	// MARK: - Runtime Tests
+	
 	/// Ensures the generated `caseName` reflects the case.
 	@Test("`caseName` matches the case")
 	func caseNameMatchesCase() {
 		@CaseName enum Status { case ready, running }
 		let state = Status.running
 		#expect(state.caseName == "running")
+	}
+	
+	/// Tests caseName with multiple cases.
+	@Test("`caseName` works with multiple cases")
+	func caseNameMultipleCases() {
+		@CaseName enum Direction { case north, south, east, west }
+		#expect(Direction.north.caseName == "north")
+		#expect(Direction.south.caseName == "south")
+		#expect(Direction.east.caseName == "east")
+		#expect(Direction.west.caseName == "west")
+	}
+	
+	/// Tests caseName with associated values.
+	@Test("`caseName` works with associated values")
+	func caseNameWithAssociatedValues() {
+		@CaseName enum Result { case success(Int), failure(String) }
+		#expect(Result.success(42).caseName == "success")
+		#expect(Result.failure("error").caseName == "failure")
+	}
+	
+	/// Tests caseName with backtick-escaped case names.
+	@Test("`caseName` handles backtick-escaped keywords")
+	func caseNameWithBackticks() {
+		@CaseName enum Keywords { case `default`, `case`, normal }
+		#expect(Keywords.default.caseName == "default")
+		#expect(Keywords.case.caseName == "case")
+		#expect(Keywords.normal.caseName == "normal")
+	}
+	
+	// MARK: - Expansion Tests
+	
+	/// Tests macro expansion generates correct switch statement.
+	@Test("Expansion generates correct switch")
+	func expansionGeneratesCorrectSwitch() {
+		assertMacroExpansion(
+			"""
+			@CaseName
+			enum Status { case ready, running }
+			""",
+			expandedSource: """
+			enum Status { case ready, running
+				var caseName: String { switch self {
+				case .ready: "ready"
+				case .running: "running"}}}
+			""",
+			macros: macros
+		)
+	}
+	
+	/// Tests macro expansion respects public access modifier.
+	@Test("Expansion respects public access modifier")
+	func expansionRespectsPublicAccess() {
+		assertMacroExpansion(
+			"""
+			@CaseName
+			public enum Status { case on, off }
+			""",
+			expandedSource: """
+			public enum Status { case on, off
+				public var caseName: String { switch self {
+				case .on: "on"
+				case .off: "off"}}}
+			""",
+			macros: macros
+		)
+	}
+	
+	/// Tests macro expansion respects private access modifier.
+	@Test("Expansion respects private access modifier")
+	func expansionRespectsPrivateAccess() {
+		assertMacroExpansion(
+			"""
+			@CaseName
+			private enum Status { case on }
+			""",
+			expandedSource: """
+			private enum Status { case on
+				private var caseName: String { switch self {
+				case .on: "on"}}}
+			""",
+			macros: macros
+		)
+	}
+	
+	// MARK: - Error Cases
+	
+	/// Tests that applying to a struct produces an error.
+	@Test("Fails when applied to struct")
+	func failsOnStruct() {
+		assertMacroExpansion(
+			"""
+			@CaseName
+			struct NotAnEnum { var x: Int }
+			""",
+			expandedSource: """
+			struct NotAnEnum { var x: Int }
+			""",
+			diagnostics: [
+				DiagnosticSpec(
+					message: "@CaseName can only be applied to enums",
+					line: 1,
+					column: 1,
+					severity: .error
+				)
+			],
+			macros: macros
+		)
+	}
+	
+	/// Tests that applying to a class produces an error.
+	@Test("Fails when applied to class")
+	func failsOnClass() {
+		assertMacroExpansion(
+			"""
+			@CaseName
+			class NotAnEnum {}
+			""",
+			expandedSource: """
+			class NotAnEnum {}
+			""",
+			diagnostics: [
+				DiagnosticSpec(
+					message: "@CaseName can only be applied to enums",
+					line: 1,
+					column: 1,
+					severity: .error
+				)
+			],
+			macros: macros
+		)
+	}
+	
+	/// Tests that applying to an empty enum produces an error.
+	@Test("Fails when applied to empty enum")
+	func failsOnEmptyEnum() {
+		assertMacroExpansion(
+			"""
+			@CaseName
+			enum Empty {}
+			""",
+			expandedSource: """
+			enum Empty {}
+			""",
+			diagnostics: [
+				DiagnosticSpec(
+					message: "@CaseName can only be applied to enums with cases",
+					line: 1,
+					column: 1,
+					severity: .error
+				)
+			],
+			macros: macros
+		)
 	}
 }
 #endif

--- a/Tests/CaseValueTests/CaseValueMacroTests.swift
+++ b/Tests/CaseValueTests/CaseValueMacroTests.swift
@@ -31,6 +31,7 @@ struct CaseValueMacroTests {
 	func extractsMultipleParameters() {
 		@CaseValue enum Point { case xy(x: Int, y: Int) }
 		let p = Point.xy(x: 10, y: 20)
+		/// Single-case enum: properties are non-optional
 		#expect(p.xyX == 10)
 		#expect(p.xyY == 20)
 	}
@@ -53,9 +54,8 @@ struct CaseValueMacroTests {
 		@CaseValue enum Handler { case action(handler: () -> Void) }
 		var called = false
 		let h = Handler.action { called = true }
-		if let action = h.actionHandler {
-			action()
-		}
+		/// Single-case enum: property is non-optional
+		h.actionHandler()
 		#expect(called)
 	}
 	
@@ -137,6 +137,7 @@ struct CaseValueMacroTests {
 		func multipleSameTypeUnnamedParameters() {
 			@CaseValue enum Pair { case values(Int, Int) }
 			let p = Pair.values(1, 2)
+			/// Single-case enum: properties are non-optional
 			#expect(p.valuesInt0 == 1)
 			#expect(p.valuesInt1 == 2)
 		}
@@ -173,9 +174,9 @@ struct CaseValueMacroTests {
 			)
 		}
 		
-		/// Tests expansion respects access modifiers.
-		@Test("Expansion respects public access modifier")
-		func expansionRespectsPublicAccess() {
+		/// Tests expansion respects access modifiers for single-case enum.
+		@Test("Expansion respects public access modifier (single-case)")
+		func expansionRespectsPublicAccessSingleCase() {
 			assertMacroExpansion(
 				"""
 				@CaseValue
@@ -183,10 +184,31 @@ struct CaseValueMacroTests {
 				""",
 				expandedSource: """
 				public enum Token { case value(Int)
-					/// `Int?` value of `Int` parameter in `.value` case.
-					public var value: Int? {
+					/// `Int` value of `Int` parameter in `.value` case.
+					public var value: Int {
 						switch self {
 						case .value(let value): value
+						}
+					}}
+				""",
+				macros: macros
+			)
+		}
+		
+		/// Tests expansion for multi-case enum produces optional types.
+		@Test("Expansion produces optional types for multi-case enum")
+		func expansionProducesOptionalForMultiCase() {
+			assertMacroExpansion(
+				"""
+				@CaseValue
+				enum Result { case success(Int), failure }
+				""",
+				expandedSource: """
+				enum Result { case success(Int), failure
+					/// `Int?` value of `Int` parameter in `.success` case.
+					var success: Int? {
+						switch self {
+						case .success(let value): value
 						default: nil
 						}
 					}}

--- a/Tests/CaseValueTests/CaseValueMacroTests.swift
+++ b/Tests/CaseValueTests/CaseValueMacroTests.swift
@@ -1,11 +1,19 @@
 #if os(macOS)
 import Testing
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
 @testable import QizhMacroKit
 @testable import QizhMacroKitMacros
 
 /// Tests for the `CaseValue` macro.
 @Suite("CaseValue macro")
 struct CaseValueMacroTests {
+	private let macros: [String: any Macro.Type] = [
+		"CaseValue": CaseValueGenerator.self
+	]
+	
+	// MARK: - Runtime Tests
+	
 	/// Ensures associated values are exposed via generated properties.
 	@Test("Extracts associated values")
 	func extractsAssociatedValues() {
@@ -16,6 +24,47 @@ struct CaseValueMacroTests {
 		let word = Token.text("hi")
 		#expect(word.int == nil)
 		#expect(word.textString == "hi")
+	}
+	
+	/// Tests multiple parameters in a single case.
+	@Test("Extracts multiple parameters")
+	func extractsMultipleParameters() {
+		@CaseValue enum Point { case xy(x: Int, y: Int) }
+		let p = Point.xy(x: 10, y: 20)
+		#expect(p.xyX == 10)
+		#expect(p.xyY == 20)
+	}
+	
+	/// Tests optional associated values.
+	@Test("Handles optional associated values")
+	func handlesOptionalValues() {
+		@CaseValue enum Container { case value(Int?), empty }
+		let withValue = Container.value(42)
+		let withNil = Container.value(nil)
+		let empty = Container.empty
+		#expect(withValue.valueInt == 42)
+		#expect(withNil.valueInt == nil)
+		#expect(empty.valueInt == nil)
+	}
+	
+	/// Tests function type parameters.
+	@Test("Handles function type parameters")
+	func handlesFunctionTypes() {
+		@CaseValue enum Handler { case action(handler: () -> Void) }
+		var called = false
+		let h = Handler.action { called = true }
+		if let action = h.actionHandler {
+			action()
+		}
+		#expect(called)
+	}
+	
+	/// Tests cases without associated values are skipped.
+	@Test("Skips cases without associated values")
+	func skipsCasesWithoutValues() {
+		@CaseValue enum Mixed { case withValue(value: Int), withoutValue }
+		let v = Mixed.withValue(value: 5)
+		#expect(v.withValueValue == 5)
 	}
 	
 	// MARK: Edge Cases
@@ -81,6 +130,69 @@ struct CaseValueMacroTests {
 			#expect(v4.fooBar == nil)
 			#expect(v4.fooBarString == nil)
 			#expect(v4.fooBarString1 == nil)
+		}
+		
+		/// Tests parameters with same type get indexed suffixes.
+		@Test("Multiple same-type unnamed parameters get indexed")
+		func multipleSameTypeUnnamedParameters() {
+			@CaseValue enum Pair { case values(Int, Int) }
+			let p = Pair.values(1, 2)
+			#expect(p.valuesInt0 == 1)
+			#expect(p.valuesInt1 == 2)
+		}
+	}
+	
+	// MARK: - Expansion Tests
+	
+	@Suite("Expansion tests")
+	struct ExpansionTests {
+		private let macros: [String: any Macro.Type] = [
+			"CaseValue": CaseValueGenerator.self
+		]
+		
+		/// Tests that applying to a struct produces an error.
+		@Test("Fails when applied to struct")
+		func failsOnStruct() {
+			assertMacroExpansion(
+				"""
+				@CaseValue
+				struct NotAnEnum { var x: Int }
+				""",
+				expandedSource: """
+				struct NotAnEnum { var x: Int }
+				""",
+				diagnostics: [
+					DiagnosticSpec(
+						message: "@CaseValue can only be applied to enums",
+						line: 1,
+						column: 1,
+						severity: .error
+					)
+				],
+				macros: macros
+			)
+		}
+		
+		/// Tests expansion respects access modifiers.
+		@Test("Expansion respects public access modifier")
+		func expansionRespectsPublicAccess() {
+			assertMacroExpansion(
+				"""
+				@CaseValue
+				public enum Token { case value(Int) }
+				""",
+				expandedSource: """
+				public enum Token { case value(Int)
+					/// `Int?` value of `Int` parameter in `.value` case.
+					public var value: Int? {
+						switch self {
+						case .value(let value): value
+						default: nil
+						}
+					}}
+				""",
+				macros: macros
+			)
 		}
 	}
 }

--- a/Tests/CaseValueTests/CaseValueMacroTests.swift
+++ b/Tests/CaseValueTests/CaseValueMacroTests.swift
@@ -141,6 +141,34 @@ struct CaseValueMacroTests {
 			#expect(p.valuesInt0 == 1)
 			#expect(p.valuesInt1 == 2)
 		}
+		
+		/// Tests parameter name same as case name uses case name only.
+		@Test("Parameter name same as case name")
+		func parameterNameSameAsCaseName() {
+			@CaseValue enum Container { case value(value: Int), empty }
+			let c = Container.value(value: 42)
+			#expect(c.value == 42)
+			#expect(Container.empty.value == nil)
+		}
+		
+		/// Tests property name collision adds type suffix.
+		@Test("Property name collision adds type suffix")
+		func propertyNameCollisionAddsTypeSuffix() {
+			@CaseValue enum Collision { case data(Int, String), none }
+			let c = Collision.data(1, "hello")
+			#expect(c.dataInt == 1)
+			#expect(c.dataString == "hello")
+		}
+		
+		/// Tests property name collision adds number suffix when type suffix also collides.
+		@Test("Property name collision adds number suffix")
+		func propertyNameCollisionAddsNumberSuffix() {
+			@CaseValue enum MultiCollision { case x(Int, Int, Int), none }
+			let m = MultiCollision.x(1, 2, 3)
+			#expect(m.xInt0 == 1)
+			#expect(m.xInt1 == 2)
+			#expect(m.xInt2 == 3)
+		}
 	}
 	
 	// MARK: - Expansion Tests

--- a/Tests/DiagnosticTests/DiagnosticTests.swift
+++ b/Tests/DiagnosticTests/DiagnosticTests.swift
@@ -158,6 +158,64 @@ struct DiagnosticTests {
 		}
 	}
 	
+	// MARK: - Diagnostic Extension Tests
+	
+	@Suite("Diagnostic Extensions")
+	struct DiagnosticExtensionTests {
+		
+		@Test("Creates error diagnostic")
+		func createsErrorDiagnostic() {
+			let source: SourceFileSyntax = "let x = 1"
+			let diagnostic = Diagnostic.error(
+				node: source,
+				message: "Test error",
+				id: .invalidUsage
+			)
+			
+			#expect(diagnostic.message == "Test error")
+			#expect(diagnostic.diagMessage.severity == .error)
+		}
+		
+		@Test("Creates warning diagnostic")
+		func createsWarningDiagnostic() {
+			let source: SourceFileSyntax = "let x = 1"
+			let diagnostic = Diagnostic.warning(
+				node: source,
+				message: "Test warning",
+				id: .noEnumCases
+			)
+			
+			#expect(diagnostic.message == "Test warning")
+			#expect(diagnostic.diagMessage.severity == .warning)
+		}
+		
+		@Test("Creates note diagnostic")
+		func createsNoteDiagnostic() {
+			let source: SourceFileSyntax = "let x = 1"
+			let diagnostic = Diagnostic.note(
+				node: source,
+				message: "Test note",
+				id: .custom("noteID")
+			)
+			
+			#expect(diagnostic.message == "Test note")
+			#expect(diagnostic.diagMessage.severity == .note)
+		}
+		
+		@Test("Creates remark diagnostic")
+		func createsRemarkDiagnostic() {
+			let source: SourceFileSyntax = "let x = 1"
+			let diagnostic = Diagnostic.remark(
+				node: source,
+				message: "Test remark",
+				id: .custom("remarkID")
+			)
+			
+			#expect(diagnostic.message == "Test remark")
+			#expect(diagnostic.diagMessage.severity == .remark)
+		}
+	}
+	
 	// MARK: - FixMessage Tests
 	
 	@Suite("FixMessage")

--- a/Tests/DiagnosticTests/DiagnosticTests.swift
+++ b/Tests/DiagnosticTests/DiagnosticTests.swift
@@ -1,0 +1,186 @@
+//
+//  DiagnosticTests.swift
+//  QizhMacroKit
+//
+//  Created by Serhii Shevchenko on 18.12.2025.
+//
+
+#if os(macOS)
+import Testing
+import SwiftSyntax
+import SwiftDiagnostics
+@testable import QizhMacroKitMacros
+
+/// Tests for `QizhMacroGeneratorDiagnostic` and related diagnostic types.
+@Suite("Diagnostic Types")
+struct DiagnosticTests {
+	
+	// MARK: - QizhMacroGeneratorDiagnostic Tests
+	
+	@Suite("QizhMacroGeneratorDiagnostic")
+	struct QizhMacroGeneratorDiagnosticTests {
+		
+		@Test("Initializes with string message ID")
+		func initWithStringID() {
+			let diagnostic = QizhMacroGeneratorDiagnostic(
+				message: "Test error message",
+				id: "testErrorID",
+				severity: .error
+			)
+			
+			#expect(diagnostic.message == "Test error message")
+			#expect(diagnostic.severity == .error)
+			// MessageID properties are private, verify it exists
+			_ = diagnostic.diagnosticID
+		}
+		
+		@Test("Initializes with QizhDiagnosticCode")
+		func initWithDiagnosticCode() {
+			let diagnostic = QizhMacroGeneratorDiagnostic(
+				message: "Missing argument",
+				id: .missingArgument,
+				severity: .error
+			)
+			
+			#expect(diagnostic.message == "Missing argument")
+			// Verify diagnosticID exists
+			_ = diagnostic.diagnosticID
+		}
+		
+		@Test("Description returns message")
+		func descriptionReturnsMessage() {
+			let diagnostic = QizhMacroGeneratorDiagnostic(
+				message: "Description test",
+				id: .invalidUsage,
+				severity: .warning
+			)
+			
+			#expect(diagnostic.description == "Description test")
+		}
+		
+		@Test("Supports all severity levels")
+		func supportsAllSeverityLevels() {
+			let error = QizhMacroGeneratorDiagnostic(message: "Error", id: "e", severity: .error)
+			let warning = QizhMacroGeneratorDiagnostic(message: "Warning", id: "w", severity: .warning)
+			let note = QizhMacroGeneratorDiagnostic(message: "Note", id: "n", severity: .note)
+			let remark = QizhMacroGeneratorDiagnostic(message: "Remark", id: "r", severity: .remark)
+			
+			#expect(error.severity == .error)
+			#expect(warning.severity == .warning)
+			#expect(note.severity == .note)
+			#expect(remark.severity == .remark)
+		}
+	}
+	
+	// MARK: - QizhDiagnosticCode Tests
+	
+	@Suite("QizhDiagnosticCode")
+	struct QizhDiagnosticCodeTests {
+		
+		@Test("Predefined codes have correct raw values")
+		func predefinedCodesRawValues() {
+			#expect(QizhDiagnosticCode.missingArgument.rawValue == "missingArgument")
+			#expect(QizhDiagnosticCode.invalidUsage.rawValue == "invalidUsage")
+			#expect(QizhDiagnosticCode.noEnumCases.rawValue == "noEnumCases")
+		}
+		
+		@Test("Custom code stores value")
+		func customCodeStoresValue() {
+			let custom = QizhDiagnosticCode.custom("myCustomCode")
+			#expect(custom.rawValue == "myCustomCode")
+		}
+		
+		@Test("RawRepresentable initializer creates custom")
+		func rawRepresentableInitializer() {
+			let code = QizhDiagnosticCode(rawValue: "fromRawValue")
+			#expect(code.rawValue == "fromRawValue")
+		}
+		
+		@Test("Description matches raw value")
+		func descriptionMatchesRawValue() {
+			#expect(QizhDiagnosticCode.missingArgument.description == "missingArgument")
+			#expect(QizhDiagnosticCode.custom("test").description == "test")
+		}
+		
+		@Test("ExpressibleByStringLiteral creates custom")
+		func stringLiteralCreatesCustom() {
+			let code: QizhDiagnosticCode = "literalCode"
+			#expect(code.rawValue == "literalCode")
+		}
+		
+		@Test("Hashable conformance")
+		func hashableConformance() {
+			let set: Set<QizhDiagnosticCode> = [.missingArgument, .invalidUsage, .custom("x")]
+			#expect(set.count == 3)
+			#expect(set.contains(.missingArgument))
+		}
+	}
+	
+	// MARK: - QizhFixMessageID Tests
+	
+	@Suite("QizhFixMessageID")
+	struct QizhFixMessageIDTests {
+		
+		@Test("Predefined IDs have correct raw values")
+		func predefinedIDsRawValues() {
+			#expect(QizhFixMessageID.addCase.rawValue == "addCase")
+		}
+		
+		@Test("Custom ID stores value")
+		func customIDStoresValue() {
+			let custom = QizhFixMessageID.custom("myFixID")
+			#expect(custom.rawValue == "myFixID")
+		}
+		
+		@Test("RawRepresentable initializer creates custom")
+		func rawRepresentableInitializer() {
+			let id = QizhFixMessageID(rawValue: "fromRawValue")
+			#expect(id.rawValue == "fromRawValue")
+		}
+		
+		@Test("Description matches raw value")
+		func descriptionMatchesRawValue() {
+			#expect(QizhFixMessageID.addCase.description == "addCase")
+			#expect(QizhFixMessageID.custom("test").description == "test")
+		}
+		
+		@Test("ExpressibleByStringLiteral creates custom")
+		func stringLiteralCreatesCustom() {
+			let id: QizhFixMessageID = "literalID"
+			#expect(id.rawValue == "literalID")
+		}
+		
+		@Test("Hashable conformance")
+		func hashableConformance() {
+			let set: Set<QizhFixMessageID> = [.addCase, .custom("x"), .custom("y")]
+			#expect(set.count == 3)
+			#expect(set.contains(.addCase))
+		}
+	}
+	
+	// MARK: - FixMessage Tests
+	
+	@Suite("FixMessage")
+	struct FixMessageTests {
+		
+		@Test("Initializes with MessageID")
+		func initWithMessageID() {
+			let messageID = MessageID(domain: "test", id: "fixIt")
+			let fix = FixMessage(message: "Apply fix", fixItID: messageID)
+			
+			#expect(fix.message == "Apply fix")
+			// MessageID properties are private, verify it exists
+			_ = fix.fixItID
+		}
+		
+		@Test("Initializes with QizhFixMessageID")
+		func initWithQizhFixMessageID() {
+			let fix = FixMessage(message: "Add a case", id: .addCase)
+			
+			#expect(fix.message == "Add a case")
+			// MessageID properties are private, verify it exists
+			_ = fix.fixItID
+		}
+	}
+}
+#endif

--- a/Tests/HelperTests/StringHelperTests.swift
+++ b/Tests/HelperTests/StringHelperTests.swift
@@ -1,0 +1,278 @@
+//
+//  StringHelperTests.swift
+//  QizhMacroKit
+//
+//  Created by Serhii Shevchenko on 18.12.2025.
+//
+
+#if os(macOS)
+import Testing
+@testable import QizhMacroKitMacros
+
+/// Tests for String helper extensions used in macro implementations.
+@Suite("String Helpers")
+struct StringHelperTests {
+	
+	// MARK: - Backtick Trimming Tests
+	
+	@Suite("withBackticksTrimmed")
+	struct BacktickTrimmingTests {
+		
+		@Test("Trims leading backtick")
+		func trimsLeadingBacktick() {
+			#expect("`keyword".withBackticksTrimmed == "keyword")
+		}
+		
+		@Test("Trims trailing backtick")
+		func trimsTrailingBacktick() {
+			#expect("keyword`".withBackticksTrimmed == "keyword")
+		}
+		
+		@Test("Trims both backticks")
+		func trimsBothBackticks() {
+			#expect("`keyword`".withBackticksTrimmed == "keyword")
+		}
+		
+		@Test("Returns unchanged when no backticks")
+		func returnsUnchangedWithoutBackticks() {
+			#expect("normal".withBackticksTrimmed == "normal")
+		}
+		
+		@Test("Handles empty string")
+		func handlesEmptyString() {
+			#expect("".withBackticksTrimmed == "")
+		}
+		
+		@Test("Handles only backticks")
+		func handlesOnlyBackticks() {
+			#expect("``".withBackticksTrimmed == "")
+		}
+	}
+	
+	// MARK: - Swift Keyword Escaping Tests
+	
+	@Suite("escapedSwiftIdentifier")
+	struct SwiftKeywordEscapingTests {
+		
+		@Test("Escapes class keyword")
+		func escapesClassKeyword() {
+			#expect("class".escapedSwiftIdentifier == "`class`")
+		}
+		
+		@Test("Escapes struct keyword")
+		func escapesStructKeyword() {
+			#expect("struct".escapedSwiftIdentifier == "`struct`")
+		}
+		
+		@Test("Escapes enum keyword")
+		func escapesEnumKeyword() {
+			#expect("enum".escapedSwiftIdentifier == "`enum`")
+		}
+		
+		@Test("Escapes func keyword")
+		func escapesFuncKeyword() {
+			#expect("func".escapedSwiftIdentifier == "`func`")
+		}
+		
+		@Test("Escapes Self keyword")
+		func escapesSelfKeyword() {
+			#expect("Self".escapedSwiftIdentifier == "`Self`")
+		}
+		
+		@Test("Escapes self keyword")
+		func escapesLowercaseSelfKeyword() {
+			#expect("self".escapedSwiftIdentifier == "`self`")
+		}
+		
+		@Test("Escapes async keyword")
+		func escapesAsyncKeyword() {
+			#expect("async".escapedSwiftIdentifier == "`async`")
+		}
+		
+		@Test("Escapes await keyword")
+		func escapesAwaitKeyword() {
+			#expect("await".escapedSwiftIdentifier == "`await`")
+		}
+		
+		@Test("Does not escape non-keywords")
+		func doesNotEscapeNonKeywords() {
+			#expect("myVariable".escapedSwiftIdentifier == "myVariable")
+			#expect("someFunction".escapedSwiftIdentifier == "someFunction")
+			#expect("CustomType".escapedSwiftIdentifier == "CustomType")
+		}
+		
+		@Test("Escapes control flow keywords")
+		func escapesControlFlowKeywords() {
+			#expect("if".escapedSwiftIdentifier == "`if`")
+			#expect("else".escapedSwiftIdentifier == "`else`")
+			#expect("for".escapedSwiftIdentifier == "`for`")
+			#expect("while".escapedSwiftIdentifier == "`while`")
+			#expect("switch".escapedSwiftIdentifier == "`switch`")
+			#expect("case".escapedSwiftIdentifier == "`case`")
+			#expect("default".escapedSwiftIdentifier == "`default`")
+		}
+	}
+	
+	// MARK: - Case Conversion Tests
+	
+	@Suite("toCamelCase")
+	struct CamelCaseTests {
+		
+		@Test("Converts snake_case")
+		func convertsSnakeCase() {
+			#expect("hello_world".toCamelCase == "helloWorld")
+		}
+		
+		@Test("Converts PascalCase")
+		func convertsPascalCase() {
+			#expect("HelloWorld".toCamelCase == "helloWorld")
+		}
+		
+		@Test("Handles single word")
+		func handlesSingleWord() {
+			#expect("hello".toCamelCase == "hello")
+		}
+		
+		@Test("Handles UPPERCASE")
+		func handlesUppercase() {
+			#expect("HELLO".toCamelCase == "hello")
+		}
+		
+		@Test("Handles mixed case")
+		func handlesMixedCase() {
+			#expect("helloWORLD".toCamelCase == "helloWorld")
+		}
+		
+		@Test("Handles acronyms")
+		func handlesAcronyms() {
+			#expect("XMLParser".toCamelCase == "xmlParser")
+			#expect("parseXML".toCamelCase == "parseXml")
+		}
+		
+		@Test("Handles numbers")
+		func handlesNumbers() {
+			#expect("value123Test".toCamelCase == "value123Test")
+		}
+	}
+	
+	@Suite("toPascalCase")
+	struct PascalCaseTests {
+		
+		@Test("Converts snake_case")
+		func convertsSnakeCase() {
+			#expect("hello_world".toPascalCase == "HelloWorld")
+		}
+		
+		@Test("Converts camelCase")
+		func convertsCamelCase() {
+			#expect("helloWorld".toPascalCase == "HelloWorld")
+		}
+		
+		@Test("Handles single word")
+		func handlesSingleWord() {
+			#expect("hello".toPascalCase == "Hello")
+		}
+		
+		@Test("Handles UPPERCASE")
+		func handlesUppercase() {
+			#expect("HELLO".toPascalCase == "Hello")
+		}
+	}
+	
+	@Suite("toSnakeCase")
+	struct SnakeCaseTests {
+		
+		@Test("Converts camelCase")
+		func convertsCamelCase() {
+			#expect("helloWorld".toSnakeCase == "hello_world")
+		}
+		
+		@Test("Converts PascalCase")
+		func convertsPascalCase() {
+			#expect("HelloWorld".toSnakeCase == "hello_world")
+		}
+		
+		@Test("Handles single word")
+		func handlesSingleWord() {
+			#expect("hello".toSnakeCase == "hello")
+		}
+		
+		@Test("Handles acronyms")
+		func handlesAcronyms() {
+			#expect("XMLParser".toSnakeCase == "xml_parser")
+		}
+	}
+	
+	@Suite("toKebabCase")
+	struct KebabCaseTests {
+		
+		@Test("Converts camelCase")
+		func convertsCamelCase() {
+			#expect("helloWorld".toKebabCase == "hello-world")
+		}
+		
+		@Test("Converts PascalCase")
+		func convertsPascalCase() {
+			#expect("HelloWorld".toKebabCase == "hello-world")
+		}
+		
+		@Test("Handles single word")
+		func handlesSingleWord() {
+			#expect("hello".toKebabCase == "hello")
+		}
+	}
+	
+	@Suite("toDotCase")
+	struct DotCaseTests {
+		
+		@Test("Converts camelCase")
+		func convertsCamelCase() {
+			#expect("helloWorld".toDotCase == "hello.world")
+		}
+		
+		@Test("Converts PascalCase")
+		func convertsPascalCase() {
+			#expect("HelloWorld".toDotCase == "hello.world")
+		}
+		
+		@Test("Handles single word")
+		func handlesSingleWord() {
+			#expect("hello".toDotCase == "hello")
+		}
+	}
+	
+	@Suite("toWordsArray")
+	struct WordsArrayTests {
+		
+		@Test("Splits camelCase into words")
+		func splitsCamelCase() {
+			let words = "helloWorld".toWordsArray()
+			#expect(words == ["hello", "world"])
+		}
+		
+		@Test("Splits PascalCase into words")
+		func splitsPascalCase() {
+			let words = "HelloWorld".toWordsArray()
+			#expect(words == ["hello", "world"])
+		}
+		
+		@Test("Handles numbers")
+		func handlesNumbers() {
+			let words = "value123test".toWordsArray()
+			#expect(words == ["value", "123", "test"])
+		}
+		
+		@Test("Handles single word")
+		func handlesSingleWord() {
+			let words = "hello".toWordsArray()
+			#expect(words == ["hello"])
+		}
+		
+		@Test("Returns empty for empty string")
+		func returnsEmptyForEmptyString() {
+			let words = "".toWordsArray()
+			#expect(words.isEmpty)
+		}
+	}
+}
+#endif

--- a/Tests/IsCaseTests/IsCaseMacroTests.swift
+++ b/Tests/IsCaseTests/IsCaseMacroTests.swift
@@ -315,14 +315,14 @@ struct IsCaseMacroTests {
 				}
 				/// A parameterless representation of `Status` cases.
 				enum Cases: Equatable, CaseIterable {
-			        case on
-			        case off
+					case on
+					case off
 				}
 				/// A parameterless representation of this case.
 				var parametersErasedCase: Cases {
 					switch self {
-			        case .on: .on
-			        case .off: .off
+					case .on: .on
+					case .off: .off
 					}
 				}
 				/// Returns `true` if `self` matches any case in `cases`.

--- a/Tests/IsCaseTests/IsCaseMacroTests.swift
+++ b/Tests/IsCaseTests/IsCaseMacroTests.swift
@@ -236,5 +236,109 @@ struct IsCaseMacroTests {
 			macros: ["IsCase": QizhMacroKitMacros.IsCasesGenerator.self]
 		)
 	}
+	
+	// MARK: - Error Cases
+	
+	/// Tests that applying to a struct produces an error.
+	@Test("Fails when applied to struct")
+	func failsOnStruct() {
+		assertMacroExpansion(
+			#"""
+			@IsCase
+			struct NotAnEnum { var x: Int }
+			"""#,
+			expandedSource:
+			#"""
+			struct NotAnEnum { var x: Int }
+			"""#,
+			diagnostics: [
+				DiagnosticSpec(
+					message: "@IsCase can only be applied to enums",
+					line: 1,
+					column: 1,
+					severity: .error
+				)
+			],
+			macros: ["IsCase": QizhMacroKitMacros.IsCasesGenerator.self]
+		)
+	}
+	
+	/// Tests that applying to an empty enum produces a warning.
+	@Test("Warns when applied to empty enum")
+	func warnsOnEmptyEnum() {
+		assertMacroExpansion(
+			#"""
+			@IsCase
+			enum Empty {}
+			"""#,
+			expandedSource:
+			#"""
+			enum Empty {}
+			"""#,
+			diagnostics: [
+				DiagnosticSpec(
+					message: "There are no cases in the enum, so `@IsCase` can NOT be applied. You may want to add a case.",
+					line: 1,
+					column: 1,
+					severity: .warning
+				)
+			],
+			macros: ["IsCase": QizhMacroKitMacros.IsCasesGenerator.self]
+		)
+	}
+	
+	/// Tests multiple cases generate switch-based properties.
+	@Test("Multiple cases generate switch-based properties")
+	func multipleCasesGenerateSwitchProperties() {
+		assertMacroExpansion(
+			#"""
+			@IsCase
+			enum Status { case on, off }
+			"""#,
+			expandedSource:
+			#"""
+			enum Status {
+				case on, off
+				/// Returns `true` if `self` is `.on`.
+				var isOn: Bool {
+					switch self {
+					case .on: true
+					default: false
+					}
+				}
+				/// Returns `true` if `self` is `.off`.
+				var isOff: Bool {
+					switch self {
+					case .off: true
+					default: false
+					}
+				}
+				/// A parameterless representation of `Status` cases.
+				enum Cases: Equatable, CaseIterable {
+			        case on
+			        case off
+				}
+				/// A parameterless representation of this case.
+				var parametersErasedCase: Cases {
+					switch self {
+			        case .on: .on
+			        case .off: .off
+					}
+				}
+				/// Returns `true` if `self` matches any case in `cases`.
+				/// - Parameter cases: An array of cases to match against.
+				func isAmong(_ cases: [Cases]) -> Bool {
+					cases.contains(self.parametersErasedCase)
+				}
+				/// Returns `true` if `self` matches any of the provided cases.
+				/// - Parameter cases: The cases to match against.
+				func isAmong(_ cases: Cases...) -> Bool {
+					isAmong(cases)
+				}
+			}
+			"""#,
+			macros: ["IsCase": QizhMacroKitMacros.IsCasesGenerator.self]
+		)
+	}
 }
 #endif

--- a/Tests/IsNotCaseTests/IsNotCaseMacroTests.swift
+++ b/Tests/IsNotCaseTests/IsNotCaseMacroTests.swift
@@ -1,11 +1,19 @@
 #if os(macOS)
 import Testing
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
 @testable import QizhMacroKit
 @testable import QizhMacroKitMacros
 
 /// Tests for the `IsNotCase` macro.
 @Suite("IsNotCase macro")
 struct IsNotCaseMacroTests {
+	private let macros: [String: any Macro.Type] = [
+		"IsNotCase": IsNotCasesGenerator.self
+	]
+	
+	// MARK: - Runtime Tests
+	
 	/// Ensures generated properties negate case checks.
 	@Test("Generated properties are negated")
 	func generatedPropertiesAreNegated() {
@@ -13,6 +21,155 @@ struct IsNotCaseMacroTests {
 		let dir = Direction.left
 		#expect(!dir.isNotLeft)
 		#expect(dir.isNotRight)
+	}
+	
+	/// Tests with multiple cases.
+	@Test("Works with multiple cases")
+	func worksWithMultipleCases() {
+		@IsNotCase enum Status { case pending, active, completed, cancelled }
+		let status = Status.active
+		#expect(status.isNotPending)
+		#expect(!status.isNotActive)
+		#expect(status.isNotCompleted)
+		#expect(status.isNotCancelled)
+	}
+	
+	/// Tests with associated values.
+	@Test("Works with associated values")
+	func worksWithAssociatedValues() {
+		@IsNotCase enum Result { case success(Int), failure(String) }
+		let result = Result.success(42)
+		#expect(!result.isNotSuccess)
+		#expect(result.isNotFailure)
+	}
+	
+	/// Tests with backtick-escaped keywords.
+	@Test("Handles backtick-escaped keywords")
+	func handlesBacktickKeywords() {
+		@IsNotCase enum Keywords { case `default`, `class`, normal }
+		let kw = Keywords.default
+		#expect(!kw.isNotDefault)
+		#expect(kw.isNotClass)
+		#expect(kw.isNotNormal)
+	}
+	
+	// MARK: - Expansion Tests
+	
+	/// Tests macro expansion generates correct switch statement.
+	@Test("Expansion generates correct switch")
+	func expansionGeneratesCorrectSwitch() {
+		assertMacroExpansion(
+			"""
+			@IsNotCase
+			enum Direction { case left, right }
+			""",
+			expandedSource: """
+			enum Direction { case left, right
+				var isNotLeft: Bool {
+					switch self {
+					case .left: false
+					default: true
+					}
+				}
+				var isNotRight: Bool {
+					switch self {
+					case .right: false
+					default: true
+					}
+				}}
+			""",
+			macros: macros
+		)
+	}
+	
+	/// Tests macro expansion respects public access modifier.
+	@Test("Expansion respects public access modifier")
+	func expansionRespectsPublicAccess() {
+		assertMacroExpansion(
+			"""
+			@IsNotCase
+			public enum Status { case on }
+			""",
+			expandedSource: """
+			public enum Status { case on
+				public var isNotOn: Bool {
+					switch self {
+					case .on: false
+					default: true
+					}
+				}}
+			""",
+			macros: macros
+		)
+	}
+	
+	/// Tests macro expansion respects private access modifier.
+	@Test("Expansion respects private access modifier")
+	func expansionRespectsPrivateAccess() {
+		assertMacroExpansion(
+			"""
+			@IsNotCase
+			private enum Status { case on }
+			""",
+			expandedSource: """
+			private enum Status { case on
+				private var isNotOn: Bool {
+					switch self {
+					case .on: false
+					default: true
+					}
+				}}
+			""",
+			macros: macros
+		)
+	}
+	
+	// MARK: - Error Cases
+	
+	/// Tests that applying to a struct produces an error.
+	@Test("Fails when applied to struct")
+	func failsOnStruct() {
+		assertMacroExpansion(
+			"""
+			@IsNotCase
+			struct NotAnEnum { var x: Int }
+			""",
+			expandedSource: """
+			struct NotAnEnum { var x: Int }
+			""",
+			diagnostics: [
+				DiagnosticSpec(
+					message: "@IsNotCase can only be applied to enums",
+					line: 1,
+					column: 1,
+					severity: .error
+				)
+			],
+			macros: macros
+		)
+	}
+	
+	/// Tests that applying to a class produces an error.
+	@Test("Fails when applied to class")
+	func failsOnClass() {
+		assertMacroExpansion(
+			"""
+			@IsNotCase
+			class NotAnEnum {}
+			""",
+			expandedSource: """
+			class NotAnEnum {}
+			""",
+			diagnostics: [
+				DiagnosticSpec(
+					message: "@IsNotCase can only be applied to enums",
+					line: 1,
+					column: 1,
+					severity: .error
+				)
+			],
+			macros: macros
+		)
 	}
 }
 #endif

--- a/Tests/IsNotCaseTests/IsNotCaseMacroTests.swift
+++ b/Tests/IsNotCaseTests/IsNotCaseMacroTests.swift
@@ -171,5 +171,46 @@ struct IsNotCaseMacroTests {
 			macros: macros
 		)
 	}
+	
+	/// Tests that non-case members are skipped.
+	@Test("Skips non-case members in enum")
+	func skipsNonCaseMembers() {
+		assertMacroExpansion(
+			"""
+			@IsNotCase
+			enum Mixed {
+				case active
+				var description: String { "" }
+				case inactive
+			}
+			""",
+			expandedSource: """
+			enum Mixed {
+				case active
+				var description: String { "" }
+				case inactive
+			
+				var isNotActive: Bool {
+					switch self {
+					case .active:
+						false
+					default:
+						true
+					}
+				}
+			
+				var isNotInactive: Bool {
+					switch self {
+					case .inactive:
+						false
+					default:
+						true
+					}
+				}
+			}
+			""",
+			macros: macros
+		)
+	}
 }
 #endif

--- a/Tests/OptionSetTests/OptionSetMacroTests.swift
+++ b/Tests/OptionSetTests/OptionSetMacroTests.swift
@@ -33,7 +33,7 @@ struct OptionSetMacroTests {
 	func testExpansionOnStructWithNestedEnumAndStatics() {
 		assertMacroExpansion(
 			"""
-			@MyOptionSet<UInt8>
+			@OptionSet<UInt8>
 			struct ShippingOptions {
 				private enum Options: Int {
 					case nextDay
@@ -95,7 +95,7 @@ struct OptionSetMacroTests {
 	func testExpansionOnPublicStructWithExplicitOptionSetConformance() {
 		assertMacroExpansion(
 			"""
-			@MyOptionSet<UInt8>
+			@OptionSet<UInt8>
 			public struct ShippingOptions: OptionSet {
 				private enum Options: Int {
 					case nextDay
@@ -138,7 +138,7 @@ struct OptionSetMacroTests {
 	func testExpansionFailsOnEnumType() {
 		assertMacroExpansion(
 			"""
-			@MyOptionSet<UInt8>
+			@OptionSet<UInt8>
 			enum Animal {
 				case dog
 			}
@@ -164,7 +164,7 @@ struct OptionSetMacroTests {
 	func testExpansionFailsWithoutNestedOptionsEnum() {
 		assertMacroExpansion(
 			"""
-			@MyOptionSet<UInt8>
+			@OptionSet<UInt8>
 			struct ShippingOptions {
 				static let express: ShippingOptions = [.nextDay, .secondDay]
 				static let all: ShippingOptions = [.express, .priority, .standard]
@@ -192,7 +192,7 @@ struct OptionSetMacroTests {
 	func testExpansionFailsWithoutSpecifiedRawType() {
 		assertMacroExpansion(
 			"""
-			@MyOptionSet
+			@OptionSet
 			struct ShippingOptions {
 				private enum Options: Int {
 					case nextDay

--- a/Tests/OptionSetTests/OptionSetMacroTests.swift
+++ b/Tests/OptionSetTests/OptionSetMacroTests.swift
@@ -323,5 +323,54 @@ struct OptionSetMacroTests {
 			indentationWidth: .spaces(2)
 		)
 	}
+	
+	/// Tests that non-case members in Options enum are skipped.
+	@Test("Skips non-case members in Options enum")
+	func testSkipsNonCaseMembersInOptionsEnum() {
+		assertMacroExpansion(
+			"""
+			@OptionSet<UInt8>
+			struct Flags {
+				private enum Options: Int {
+					case enabled
+					var description: String { "" }
+					case disabled
+				}
+			}
+			""",
+			expandedSource: """
+				struct Flags {
+					private enum Options: Int {
+						case enabled
+						var description: String { "" }
+						case disabled
+					}
+
+					typealias RawValue = UInt8
+
+					var rawValue: RawValue
+
+					init() {
+						self.rawValue = 0
+					}
+
+					init(rawValue: RawValue) {
+						self.rawValue = rawValue
+					}
+
+					static let enabled: Self =
+						Self(rawValue: 1 << Options.enabled.rawValue)
+
+					static let disabled: Self =
+						Self(rawValue: 1 << Options.disabled.rawValue)
+				}
+
+				extension Flags: OptionSet {
+				}
+				""",
+			macros: macros,
+			indentationWidth: .spaces(2)
+		)
+	}
 }
 #endif

--- a/Tests/OptionSetTests/OptionSetMacroTests.swift
+++ b/Tests/OptionSetTests/OptionSetMacroTests.swift
@@ -217,5 +217,111 @@ struct OptionSetMacroTests {
 			indentationWidth: .spaces(2)
 		)
 	}
+	
+	@Test("Expansion with custom optionsName argument")
+	func testExpansionWithCustomOptionsName() {
+		assertMacroExpansion(
+			"""
+			@OptionSet<UInt8>(optionsName: "Flags")
+			struct Permissions {
+				private enum Flags: Int {
+					case read
+					case write
+				}
+			}
+			""",
+			expandedSource: """
+				struct Permissions {
+					private enum Flags: Int {
+						case read
+						case write
+					}
+
+					typealias RawValue = UInt8
+
+					var rawValue: RawValue
+
+					init() {
+						self.rawValue = 0
+					}
+
+					init(rawValue: RawValue) {
+						self.rawValue = rawValue
+					}
+
+					static let read: Self =
+						Self(rawValue: 1 << Flags.read.rawValue)
+
+					static let write: Self =
+						Self(rawValue: 1 << Flags.write.rawValue)
+				}
+
+				extension Permissions: OptionSet {
+				}
+				""",
+			macros: macros,
+			indentationWidth: .spaces(2)
+		)
+	}
+	
+	@Test("Expansion fails with non-string literal optionsName")
+	func testExpansionFailsWithNonStringLiteralOptionsName() {
+		assertMacroExpansion(
+			"""
+			@OptionSet<UInt8>(optionsName: someVariable)
+			struct Permissions {
+				private enum Options: Int {
+					case read
+				}
+			}
+			""",
+			expandedSource: """
+				struct Permissions {
+					private enum Options: Int {
+						case read
+					}
+				}
+				""",
+			diagnostics: [
+				DiagnosticSpec(
+					message: "'OptionSet' macro argument optionsName must be a string literal",
+					line: 1,
+					column: 31
+				)
+			],
+			macros: macros,
+			indentationWidth: .spaces(2)
+		)
+	}
+	
+	@Test("Expansion fails when custom optionsName enum is missing")
+	func testExpansionFailsWhenCustomOptionsEnumMissing() {
+		assertMacroExpansion(
+			"""
+			@OptionSet<UInt8>(optionsName: "CustomOptions")
+			struct Permissions {
+				private enum Options: Int {
+					case read
+				}
+			}
+			""",
+			expandedSource: """
+				struct Permissions {
+					private enum Options: Int {
+						case read
+					}
+				}
+				""",
+			diagnostics: [
+				DiagnosticSpec(
+					message: "'OptionSet' macro requires nested options enum 'CustomOptions'",
+					line: 1,
+					column: 1
+				)
+			],
+			macros: macros,
+			indentationWidth: .spaces(2)
+		)
+	}
 }
 #endif


### PR DESCRIPTION
## Summary

Expand test coverage from `~80%` to **`99%`✨** by adding edge case tests and documenting untestable code paths.

## Changes

### New Tests
- **`CaseValueMacroTests`**
  Parameter name same as case name, property collision with type/number suffix
- **`CaseNameMacroTests`**
  Enum with non-case members (computed properties, methods)
- **`IsNotCaseMacroTests`**
  Enum with non-case members
- **`OptionSetMacroTests`**
  Custom `optionsName` argument, invalid string literal, Options enum with non-case members
- **`DiagnosticTests`**
  `Diagnostic.note` and `Diagnostic.remark` extension tests

### CaseValueGenerator Enhancement
- Single-case enums now generate **non-optional** properties (avoids "Default will never be executed" warning)

### Documentation
- **`AGENTS.md`**
  Added auto-commit policy with conditions and commit message format
- **`KNOWN_ISSUES.md`**
  Documented untestable `_QizhMacroKitMacro.swift` plugin entry point

### Code Style (`OptionSetGenerator`)
- Refactored to modern Swift style with implicit returns
- ✨ Line **`69`**: Nice. ✨

## Testing
- **`120` tests passing** across `23` suites
- All macro generators covered with edge case tests

<details><summary> <h3>Previously in this PR</h3></summary>

This pull request adds comprehensive documentation and improves platform compatibility handling for the macro implementation code. The most significant change is the addition of the `AGENTS.md` file, which documents project structure, coding conventions, macro implementation patterns, and agent responsibilities. Additionally, the import of `SwiftCompilerPlugin` in `StringifyGenerator.swift` is now conditionally compiled to support non-macOS platforms.

**Documentation and Project Guidelines:**

- Added `AGENTS.md` with detailed information on project overview, structure, coding conventions, macro implementation patterns, agent responsibilities, and CI/CD practices.

**Platform Compatibility:**

- Changed the import of `SwiftCompilerPlugin` in `StringifyGenerator.swift` to be conditional using `#if canImport(SwiftCompilerPlugin)`, improving compatibility with platforms where this module is unavailable.
</details> 