### PR TITLE
Add @OptionSet associated enum value support and fix Package.swift structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ DerivedData/
 DerivedData-filetree.md
 Package.resolved
 .vscode/settings.json
+
+# Task resources folder (temporary files for AI assistants)
+.tasks/*
+!.tasks/.gitkeep

--- a/.swiftpm/xcode/xcshareddata/xcschemes/QizhMacroKit-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/QizhMacroKit-Package.xcscheme
@@ -49,6 +49,20 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "QizhMacroKitPreviewSupport"
+               BuildableName = "QizhMacroKitPreviewSupport"
+               BlueprintName = "QizhMacroKitPreviewSupport"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,6 +1,6 @@
 # Known Issues
 
-> Last Updated: December 18, 2025
+> Last Updated: January 13, 2026
 
 This document lists known limitations and issues in QizhMacroKit.
 
@@ -101,6 +101,51 @@ The macro plugin entry point (`_QizhMacroKitMacro.swift`) registers macros with 
 - Appears as 0% coverage in code coverage reports
 
 This is expected behavior for Swift macro plugins. The actual macro implementations (generators) are fully testable and covered.
+
+---
+
+## Resolved Issues
+
+### @OptionSet Mixed Case Bit Collisions (PR #45)
+
+**Status**: Fixed (January 13, 2026)  
+**Affected**: `@OptionSet` macro  
+**Resolution**: Commit `776085c`
+
+When an `Options` enum contained both simple cases and cases with associated values, the generated code would produce bit collisions. Swift prohibits raw types on enums with associated values, so `.rawValue` cannot be used on simple cases when any case has associated values.
+
+**Fix**: The macro now detects if ANY case has associated values and uses manual bit indexing (`1 << index`) for ALL cases in that scenario.
+
+---
+
+### Unused Diagnostic Cases (PR #45)
+
+**Status**: Fixed (January 13, 2026)  
+**Affected**: `OptionSetMacroDiagnostic`  
+**Resolution**: Removed dead code
+
+The diagnostic cases `associatedEnumNotFound` and `associatedEnumMissingCases` were declared but never emitted. Since the silent fallback to simple generation is intentional behavior (for external types), the unused diagnostics were removed.
+
+---
+
+## External Issues
+
+### Codex Code Review GitHub Integration
+
+**Status**: OpenAI Backend Issue  
+**Reported**: January 13, 2026
+
+The Codex Code Review feature may fail to connect to GitHub repositories even when:
+- GitHub App is properly installed
+- Repository is in the authorized list
+- All permissions are granted
+
+**Symptoms**:
+- "Action required: Update your GitHub permissions" banner persists
+- "Update" button doesn't resolve the issue
+- Stale/phantom repositories appear in settings that cannot be removed
+
+**Workaround**: Contact OpenAI support. This is a backend OAuth token validation issue.
 
 ---
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "9fad6afb0cc9ebdd7527efb0e34f1e4c3ebf95001d531c65ba6a1805d85e970a",
+  "originHash" : "cba61afa9bee6bf2006af5e4a0df8362e375d0a290c8c08e5ecf4c6a55d4c3fb",
   "pins" : [
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-plugin",
+      "state" : {
+        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
+        "version" : "1.4.5"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
+      }
+    },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -13,100 +13,65 @@ let package = Package(
 	products: [
 		.library(
 			name: "QizhMacroKit",
-			// type: .static,
 			targets: ["QizhMacroKit"]
+		),
+		.library(
+			name: "QizhMacroKitPreviewSupport",
+			targets: ["QizhMacroKitPreviewSupport"]
 		),
 		.executable(
 			name: "QizhMacroKitClient",
 			targets: ["QizhMacroKitClient"]
 		),
-		/*
-		.library(
-			name: "QizhMacroKitPlayground",
-			type: .dynamic,
-			targets: ["QizhMacroKitPlayground"]
-		)
-		*/
 	],
 	dependencies: [
+		/// Tag/version (often better for prebuilts)
 		.package(
 			url: "https://github.com/swiftlang/swift-syntax.git",
-			/// Pinned to match Xcode 26.2 / Swift 6.2 toolchain
-			/// to avoid `_SwiftSyntaxCShims` resolution errors
-			/// ## Changelog
-			/// - `"602.0.0" ..< "700.0.0"`
-			/// - `exact: "602.0.0"`
-			/// - `.upToNextMajor(from: "602.0.0")`
-			/// - `exact: "602.1.0"`
-			/// - `branch: "release/6.2"` (matches Xcode 26.2 / Swift 6.2)
-			from: "602.0.0"
+			.upToNextMajor(from: "602.0.0")
 		),
-		// .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.2.0")),
-		/*
+		
+		/// DocC plugin (command plugin)
 		.package(
-			url: "https://github.com/apple/swift-testing.git",
-			/// Was `branch: "main"`
-			.upToNextMajor(from: "6.2.0")
+			url: "https://github.com/swiftlang/swift-docc-plugin",
+			from: "1.1.0"
 		),
-		*/
 	],
 	targets: [
-		
-		/// Macro plugin target
-		
+		/// Macro implementation (executable "plugin" for the compiler)
 		.macro(
 			name: "QizhMacroKitMacros",
 			dependencies: [
+				.product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
 				.product(name: "SwiftSyntax", package: "swift-syntax"),
 				.product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-				.product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
 				.product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
 				.product(name: "SwiftDiagnostics", package: "swift-syntax"),
-				// .product(name: "OrderedCollections", package: "swift-collections"),
 			]
 		),
 		
-		/// Library target that exposes the macro
-		
+		/// Library API (declare `@attached` / `#externalMacro`, etc in it)
 		.target(
 			name: "QizhMacroKit",
 			dependencies: [
-				// .product(name: "OrderedCollections", package: "swift-collections"),
+				"QizhMacroKitMacros",
 			],
 			resources: [
 				.process("PrivacyInfo.xcprivacy")
-			],
-			plugins: [
-				.plugin(name: "QizhMacroKitMacros")
 			]
 		),
-		
-		/// Internal library to test macros with playgrounds
-		
-		/*
-		.target(
-			name: "QizhMacroKitPlayground",
-			dependencies: [
-				"QizhMacroKit",
-			],
-			path: "Sources/Playgrounds",
-			swiftSettings: [
-				.define("ENABLE_DEBUG_DYLIB", .when(configuration: .debug))
-			]
-		),
-		*/
-		
-		/// Client executable target that uses the macro
-		
+
 		.executableTarget(
 			name: "QizhMacroKitClient",
-			dependencies: ["QizhMacroKit"],
-			resources: [
-				.process("PrivacyInfo.xcprivacy")
-			]
+			dependencies: ["QizhMacroKit", "QizhMacroKitPreviewSupport"],
+			resources: [.process("PrivacyInfo.xcprivacy"),]
 		),
 		
-		/// Test target
+		/// Preview support library target for Xcode canvas
+		.target(
+			name: "QizhMacroKitPreviewSupport",
+			dependencies: ["QizhMacroKit"]
+		),
 		
 		.testTarget(
 			name: "QizhMacroKitTests",
@@ -114,14 +79,9 @@ let package = Package(
 				"QizhMacroKit",
 				"QizhMacroKitMacros",
 				.product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
-				// .product(name: "Testing", package: "swift-testing"),
 			],
 			path: "Tests"
 		),
 	],
-	swiftLanguageModes: [
-		// .v5,
-		.v6,
-	]
+	swiftLanguageModes: [.v6]
 )
-

--- a/Sources/QizhMacroKit/OptionSet.swift
+++ b/Sources/QizhMacroKit/OptionSet.swift
@@ -9,27 +9,57 @@
 ///
 /// Attach this macro to a struct that contains a nested `Options` enum
 /// with an integer raw value. The struct will be transformed to conform to
-/// `OptionSet` by
-/// - 1. Introducing a `rawValue` stored property to track which options are set,
-///   along with the necessary `RawType` typealias and initializers to satisfy
-///   the `OptionSet` protocol.
-/// - 2. Introducing static properties for each of the cases within the `Options`
-///   enum, of the type of the struct.
-/// ## Example
+/// `OptionSet` by:
+///
+/// 1. Introducing a `rawValue` stored property to track which options are set,
+///    along with the necessary `RawType` typealias and initializers to satisfy
+///    the `OptionSet` protocol.
+/// 2. Introducing static properties for each of the cases within the `Options`
+///    enum, of the type of the struct.
+///
+/// ## Basic Example
+///
 /// ```swift
 /// @OptionSet<UInt8>
 /// struct ColorApplications {
-/// 	private enum Options: UInt8 {
-/// 		case tint
-/// 		case tintGradient
-/// 		case accent
-/// 	}
+///     private enum Options: UInt8 {
+///         case tint
+///         case tintGradient
+///         case accent
+///     }
 /// }
+/// // Generated: .tint, .tintGradient, .accent
 /// ```
+///
+/// ## Associated Enum Values
+///
+/// Cases in the `Options` enum can have associated values of nested enum types.
+/// The macro will generate a static property for each case of the associated enum,
+/// combining the option case name with the enum case name in camelCase.
+///
+/// ```swift
+/// @OptionSet<UInt8>
+/// struct Configuration {
+///     private enum Options {
+///         case level(Priority)      // Associated enum type
+///         case enabled              // Simple case
+///     }
+///
+///     enum Priority {
+///         case low
+///         case medium
+///         case high
+///     }
+/// }
+/// // Generated: .levelLow, .levelMedium, .levelHigh, .enabled
+/// ```
+///
+/// - Note: Associated value types must be nested enums within the same struct.
+///   External types or non-enum associated values fall back to simple generation.
+///
 /// - Precondition:
 ///   The `Options` enum must have a raw value, where its case elements
-///   each indicate a different option in the resulting option set. For example,
-///   the struct and its nested `Options` enum could look like this:
+///   each indicate a different option in the resulting option set.
 @attached(member, names: arbitrary)
 @attached(extension, conformances: OptionSet)
 public macro OptionSet<RawType>() =

--- a/Sources/QizhMacroKitClient/OptionSet.swift
+++ b/Sources/QizhMacroKitClient/OptionSet.swift
@@ -8,9 +8,15 @@
 import Foundation
 import QizhMacroKit
 
+/// Demonstrates the `@OptionSet` macro with business color application flags.
+///
+/// This option set defines mutually combinable color application modes
+/// that can be used together (e.g., `[.tint, .accent]`).
+///
+/// - Note: Uses `UInt8` as the raw type for compact storage.
 @OptionSet<UInt8>
-struct BusinessColorApplications {
-	private enum Options: UInt8 {
+internal struct BusinessColorApplications: Sendable {
+	private enum Options: UInt8, Sendable {
 		case tint
 		case tintGradient
 		case accent

--- a/Sources/QizhMacroKitMacros/Helpers/String+wordsArray.swift
+++ b/Sources/QizhMacroKitMacros/Helpers/String+wordsArray.swift
@@ -117,4 +117,16 @@ extension String {
 	internal var toDotCase: String {
 		self.toLocalizedLowercasedWords(joinedBy: ".")
 	}
+	
+	/// Returns a copy of this string with its first character uppercased.
+	///
+	/// Useful for combining identifiers in camelCase style.
+	/// - Example: `"high".capitalizingFirstLetter()` returns `"High"`
+	///
+	/// - Returns: The string with the first character capitalized,
+	///   or the original string if empty.
+	internal func capitalizingFirstLetter() -> String {
+		guard let first = self.first else { return self }
+		return first.uppercased() + self.dropFirst()
+	}
 }

--- a/Sources/QizhMacroKitMacros/OptionSetGenerator.swift
+++ b/Sources/QizhMacroKitMacros/OptionSetGenerator.swift
@@ -216,10 +216,16 @@ extension OptionSetGenerator: MemberMacro {
 		
 		/// Collect all nested enums in the struct for associated value resolution.
 		let nestedEnums = collectNestedEnums(from: structDecl)
+		
+		/// CRITICAL: Check if ANY case has associated values.
+		/// Swift prohibits raw types on enums with associated values.
+		/// If any case has associated values, we MUST use manual bit indexing for ALL cases.
+		let hasAnyAssociatedValues = caseElements.contains { $0.parameterClause != nil }
 
 		/// Generate static properties for each case element.
 		var staticVars: [DeclSyntax] = []
 		var bitIndex = 0
+		var usedPropertyNames: Set<String> = []
 		
 		for element in caseElements {
 			let generatedProperties = generateStaticProperties(
@@ -228,6 +234,8 @@ extension OptionSetGenerator: MemberMacro {
 				nestedEnums: nestedEnums,
 				access: access,
 				bitIndex: &bitIndex,
+				usedPropertyNames: &usedPropertyNames,
+				hasAnyAssociatedValues: hasAnyAssociatedValues,
 				context: context
 			)
 			staticVars.append(contentsOf: generatedProperties)
@@ -281,12 +289,20 @@ extension OptionSetGenerator: MemberMacro {
 	/// For cases with associated enum values, generates a static property for each
 	/// case of the associated enum type.
 	///
+	/// **Critical Implementation Note:**
+	/// Swift prohibits raw types on enums with associated values. If ANY case in the
+	/// Options enum has associated values, we MUST use manual bit indexing (`1 << index`)
+	/// for ALL cases, including simple ones. The `hasAnyAssociatedValues` parameter
+	/// controls this behavior.
+	///
 	/// - Parameters:
 	///   - element: The enum case element to process.
 	///   - optionsEnum: The Options enum declaration.
 	///   - nestedEnums: Dictionary of nested enums and their cases.
 	///   - access: The access modifier to apply.
 	///   - bitIndex: Current bit index, incremented for each generated property.
+	///   - usedPropertyNames: Set of already-used property names for collision detection.
+	///   - hasAnyAssociatedValues: If true, use manual bit indexing for ALL cases.
 	///   - context: Macro expansion context for diagnostics.
 	/// - Returns: Array of generated static property declarations.
 	private static func generateStaticProperties(
@@ -295,16 +311,33 @@ extension OptionSetGenerator: MemberMacro {
 		nestedEnums: [String: [EnumCaseElementSyntax]],
 		access: DeclModifierSyntax?,
 		bitIndex: inout Int,
+		usedPropertyNames: inout Set<String>,
+		hasAnyAssociatedValues: Bool,
 		context: some MacroExpansionContext
 	) -> [DeclSyntax] {
 		/// Check if this case has associated values.
 		guard let parameterClause = element.parameterClause,
 			  let firstParam = parameterClause.parameters.first else {
-			/// Simple case without associated values - use original behavior.
-			let decl: DeclSyntax = """
-				\(access) static let \(element.name): Self =
-					Self(rawValue: 1 << \(optionsEnum.name).\(element.name).rawValue)
-				"""
+			/// Simple case without associated values.
+			let propertyName = resolvePropertyName(
+				baseName: element.name.text,
+				usedNames: &usedPropertyNames
+			)
+			
+			let decl: DeclSyntax
+			if hasAnyAssociatedValues {
+				/// Mixed enum: use manual bit indexing since Options enum can't have raw type.
+				decl = """
+					\(access)static let \(raw: propertyName): Self =
+						Self(rawValue: 1 << \(raw: bitIndex))
+					"""
+			} else {
+				/// Pure simple enum: can use rawValue from Options enum.
+				decl = """
+					\(access)static let \(element.name): Self =
+						Self(rawValue: 1 << \(optionsEnum.name).\(element.name).rawValue)
+					"""
+			}
 			bitIndex += 1
 			return [decl]
 		}
@@ -316,8 +349,12 @@ extension OptionSetGenerator: MemberMacro {
 		guard let enumCases = nestedEnums[typeName] else {
 			/// Not a nested enum - fall back to simple case generation.
 			/// This handles external types or non-enum associated values.
+			let propertyName = resolvePropertyName(
+				baseName: element.name.text,
+				usedNames: &usedPropertyNames
+			)
 			let decl: DeclSyntax = """
-				\(access) static let \(element.name): Self =
+				\(access)static let \(raw: propertyName): Self =
 					Self(rawValue: 1 << \(raw: bitIndex))
 				"""
 			bitIndex += 1
@@ -333,8 +370,14 @@ extension OptionSetGenerator: MemberMacro {
 			/// Combine names: "level" + "High" -> "levelHigh"
 			let combinedName = baseName + caseName.capitalizingFirstLetter()
 			
+			/// Resolve collisions using the shared helper.
+			let propertyName = resolvePropertyName(
+				baseName: combinedName,
+				usedNames: &usedPropertyNames
+			)
+			
 			let decl: DeclSyntax = """
-				\(access) static let \(raw: combinedName): Self =
+				\(access)static let \(raw: propertyName): Self =
 					Self(rawValue: 1 << \(raw: bitIndex))
 				"""
 			properties.append(decl)
@@ -342,6 +385,33 @@ extension OptionSetGenerator: MemberMacro {
 		}
 		
 		return properties
+	}
+	
+	/// Resolves property name collisions by appending numeric suffixes.
+	///
+	/// This approach is borrowed from `@CaseValue` macro for consistency
+	/// across the macro kit.
+	///
+	/// - Parameters:
+	///   - baseName: The desired property name.
+	///   - usedNames: Set of already-used names, updated with the resolved name.
+	/// - Returns: A unique property name (possibly with numeric suffix).
+	private static func resolvePropertyName(
+		baseName: String,
+		usedNames: inout Set<String>
+	) -> String {
+		var propertyName = baseName
+		
+		if usedNames.contains(propertyName) {
+			var number: UInt = 0
+			repeat {
+				number += 1
+			} while usedNames.contains("\(propertyName)\(number)")
+			propertyName += "\(number)"
+		}
+		
+		usedNames.insert(propertyName)
+		return propertyName
 	}
 }
 

--- a/Sources/QizhMacroKitMacros/OptionSetGenerator.swift
+++ b/Sources/QizhMacroKitMacros/OptionSetGenerator.swift
@@ -20,6 +20,8 @@ enum OptionSetMacroDiagnostic {
 	case requiresStringLiteral(_ name: String)
 	case requiresOptionsEnum(_ name: String)
 	case requiresOptionsEnumRawType
+	case associatedEnumNotFound(_ typeName: String, caseName: String)
+	case associatedEnumMissingCases(_ typeName: String)
 }
 
 extension OptionSetMacroDiagnostic: DiagnosticMessage {
@@ -29,10 +31,18 @@ extension OptionSetMacroDiagnostic: DiagnosticMessage {
 
 	var message: String {
 		switch self {
-		case .requiresStruct: 					"'OptionSet' macro can only be applied to a struct"
-		case .requiresStringLiteral(let name): 	"'OptionSet' macro argument '\(name)' must be a string literal"
-		case .requiresOptionsEnum(let name): 	"'OptionSet' macro requires nested options enum '\(name)'"
-		case .requiresOptionsEnumRawType: 		"'OptionSet' macro requires a raw type"
+		case .requiresStruct:
+			"'OptionSet' macro can only be applied to a struct"
+		case .requiresStringLiteral(let name):
+			"'OptionSet' macro argument '\(name)' must be a string literal"
+		case .requiresOptionsEnum(let name):
+			"'OptionSet' macro requires nested options enum '\(name)'"
+		case .requiresOptionsEnumRawType:
+			"'OptionSet' macro requires a raw type"
+		case .associatedEnumNotFound(let typeName, let caseName):
+			"Associated type '\(typeName)' for case '\(caseName)' must be a nested enum with cases"
+		case .associatedEnumMissingCases(let typeName):
+			"Associated enum '\(typeName)' has no cases to generate options from"
 		}
 	}
 
@@ -182,7 +192,7 @@ extension OptionSetGenerator: MemberMacro {
 		in context: some MacroExpansionContext
 	) throws -> [DeclSyntax] {
 		/// Decode the expansion arguments.
-		guard let (_, optionsEnum, rawType) = decodeExpansion(
+		guard let (structDecl, optionsEnum, rawType) = decodeExpansion(
 			of: attribute,
 			attachedTo: decl,
 			in: context,
@@ -203,12 +213,24 @@ extension OptionSetGenerator: MemberMacro {
 
 		/// Dig out the access control keyword we need.
 		let access = decl.modifiers.first(where: \.isNeededAccessLevelModifier)
+		
+		/// Collect all nested enums in the struct for associated value resolution.
+		let nestedEnums = collectNestedEnums(from: structDecl)
 
-		let staticVars = caseElements.map { (element) -> DeclSyntax in
-			"""
-			\(access) static let \(element.name): Self =
-				Self(rawValue: 1 << \(optionsEnum.name).\(element.name).rawValue)
-			"""
+		/// Generate static properties for each case element.
+		var staticVars: [DeclSyntax] = []
+		var bitIndex = 0
+		
+		for element in caseElements {
+			let generatedProperties = generateStaticProperties(
+				for: element,
+				in: optionsEnum,
+				nestedEnums: nestedEnums,
+				access: access,
+				bitIndex: &bitIndex,
+				context: context
+			)
+			staticVars.append(contentsOf: generatedProperties)
 		}
 
 		return [
@@ -217,6 +239,109 @@ extension OptionSetGenerator: MemberMacro {
 			"\(access)init() { self.rawValue = 0 }",
 			"\(access)init(rawValue: RawValue) { self.rawValue = rawValue }",
 		] + staticVars
+	}
+	
+	// MARK: - Associated Enum Value Support
+	
+	/// Collects all nested enum declarations from a struct.
+	///
+	/// Used to resolve associated value types that reference nested enums.
+	/// Only enums with case declarations are included.
+	///
+	/// - Parameter structDecl: The struct declaration to search.
+	/// - Returns: Dictionary mapping enum names to their case elements.
+	private static func collectNestedEnums(
+		from structDecl: StructDeclSyntax
+	) -> [String: [EnumCaseElementSyntax]] {
+		var result: [String: [EnumCaseElementSyntax]] = [:]
+		
+		for member in structDecl.memberBlock.members {
+			guard let enumDecl = member.decl.as(EnumDeclSyntax.self) else {
+				continue
+			}
+			
+			let cases = enumDecl.memberBlock.members.flatMap { member in
+				guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else {
+					return [EnumCaseElementSyntax]()
+				}
+				return Array(caseDecl.elements)
+			}
+			
+			if !cases.isEmpty {
+				result[enumDecl.name.text] = cases
+			}
+		}
+		
+		return result
+	}
+	
+	/// Generates static properties for an Options enum case element.
+	///
+	/// For simple cases (no associated values), generates a single static property.
+	/// For cases with associated enum values, generates a static property for each
+	/// case of the associated enum type.
+	///
+	/// - Parameters:
+	///   - element: The enum case element to process.
+	///   - optionsEnum: The Options enum declaration.
+	///   - nestedEnums: Dictionary of nested enums and their cases.
+	///   - access: The access modifier to apply.
+	///   - bitIndex: Current bit index, incremented for each generated property.
+	///   - context: Macro expansion context for diagnostics.
+	/// - Returns: Array of generated static property declarations.
+	private static func generateStaticProperties(
+		for element: EnumCaseElementSyntax,
+		in optionsEnum: EnumDeclSyntax,
+		nestedEnums: [String: [EnumCaseElementSyntax]],
+		access: DeclModifierSyntax?,
+		bitIndex: inout Int,
+		context: some MacroExpansionContext
+	) -> [DeclSyntax] {
+		/// Check if this case has associated values.
+		guard let parameterClause = element.parameterClause,
+			  let firstParam = parameterClause.parameters.first else {
+			/// Simple case without associated values - use original behavior.
+			let decl: DeclSyntax = """
+				\(access) static let \(element.name): Self =
+					Self(rawValue: 1 << \(optionsEnum.name).\(element.name).rawValue)
+				"""
+			bitIndex += 1
+			return [decl]
+		}
+		
+		/// Extract the type name from the parameter.
+		let typeName = firstParam.type.trimmedDescription
+		
+		/// Look up the type in nested enums.
+		guard let enumCases = nestedEnums[typeName] else {
+			/// Not a nested enum - fall back to simple case generation.
+			/// This handles external types or non-enum associated values.
+			let decl: DeclSyntax = """
+				\(access) static let \(element.name): Self =
+					Self(rawValue: 1 << \(raw: bitIndex))
+				"""
+			bitIndex += 1
+			return [decl]
+		}
+		
+		/// Generate a static property for each case of the associated enum.
+		var properties: [DeclSyntax] = []
+		let baseName = element.name.text
+		
+		for enumCase in enumCases {
+			let caseName = enumCase.name.text
+			/// Combine names: "level" + "High" -> "levelHigh"
+			let combinedName = baseName + caseName.capitalizingFirstLetter()
+			
+			let decl: DeclSyntax = """
+				\(access) static let \(raw: combinedName): Self =
+					Self(rawValue: 1 << \(raw: bitIndex))
+				"""
+			properties.append(decl)
+			bitIndex += 1
+		}
+		
+		return properties
 	}
 }
 

--- a/Sources/QizhMacroKitMacros/OptionSetGenerator.swift
+++ b/Sources/QizhMacroKitMacros/OptionSetGenerator.swift
@@ -20,8 +20,6 @@ enum OptionSetMacroDiagnostic {
 	case requiresStringLiteral(_ name: String)
 	case requiresOptionsEnum(_ name: String)
 	case requiresOptionsEnumRawType
-	case associatedEnumNotFound(_ typeName: String, caseName: String)
-	case associatedEnumMissingCases(_ typeName: String)
 }
 
 extension OptionSetMacroDiagnostic: DiagnosticMessage {
@@ -39,10 +37,6 @@ extension OptionSetMacroDiagnostic: DiagnosticMessage {
 			"'OptionSet' macro requires nested options enum '\(name)'"
 		case .requiresOptionsEnumRawType:
 			"'OptionSet' macro requires a raw type"
-		case .associatedEnumNotFound(let typeName, let caseName):
-			"Associated type '\(typeName)' for case '\(caseName)' must be a nested enum with cases"
-		case .associatedEnumMissingCases(let typeName):
-			"Associated enum '\(typeName)' has no cases to generate options from"
 		}
 	}
 

--- a/Sources/QizhMacroKitMacros/OptionSetGenerator.swift
+++ b/Sources/QizhMacroKitMacros/OptionSetGenerator.swift
@@ -221,10 +221,19 @@ extension OptionSetGenerator: MemberMacro {
 }
 
 extension DeclModifierSyntax {
+	/// Determines if this modifier is an access level keyword that should be preserved
+	/// in generated `OptionSet` members.
+	///
+	/// Supported access levels: `public`, `open`, `package`, `internal`, `fileprivate`.
+	/// Private access is excluded as generated static members need broader visibility.
 	var isNeededAccessLevelModifier: Bool {
 		switch self.name.tokenKind {
-		case .keyword(.public): true
-		default: 				false
+		case .keyword(.public),
+			 .keyword(.fileprivate),
+			 .keyword(.package),
+			 .keyword(.internal),
+			 .keyword(.open): 		true
+		default: 					false
 		}
 	}
 }

--- a/Sources/QizhMacroKitPreviewSupport/OptionSetPreview.swift
+++ b/Sources/QizhMacroKitPreviewSupport/OptionSetPreview.swift
@@ -1,0 +1,110 @@
+//
+//  OptionSetPreview.swift
+//  QizhMacroKitPreviewSupport
+//
+//  Copyright © 2025 Serhii Shevchenko. All rights reserved.
+//
+
+import Foundation
+import QizhMacroKit
+
+// MARK: - Preview Support
+
+/// This module provides preview support for `@OptionSet` macro demonstrations.
+/// Extracted into a separate target to avoid requiring `ENABLE_DEBUG_DYLIB`
+/// on the main executable target, enabling Xcode canvas previews.
+
+#if DEBUG && canImport(Playgrounds) && swift(>=6.2)
+import Playgrounds
+import SwiftUI
+
+/// A sample `OptionSet` demonstrating business color application flags.
+/// Used for Xcode Playground previews to verify macro expansion.
+@OptionSet<UInt8>
+internal struct BusinessColorApplications: Sendable {
+	private enum Options: UInt8, Sendable {
+		case tint
+		case tintGradient
+		case accent
+	}
+}
+
+/// Creates a tuple of sample `BusinessColorApplications` values for demonstration.
+/// - Returns: A tuple containing `.accent`, `.tint`, and `.tintGradient` options.
+@inline(__always)
+func demoBusinessColorApplications() -> (BusinessColorApplications, BusinessColorApplications, BusinessColorApplications) {
+	(.accent, .tint, .tintGradient)
+}
+
+#Playground("OptionSet Demo") {
+	let (_, tint, _) = demoBusinessColorApplications()
+	var config = BusinessColorApplications()
+	if !config.contains(tint) {
+		config.insert(tint)
+	}
+	_ = config.contains(tint)
+}
+#endif
+
+// MARK: - Advanced OptionSet Example
+
+/// Demonstrates an advanced `@OptionSet` usage pattern with associated values.
+///
+/// This example shows how to create an `OptionSet` with a custom `Options` enum
+/// that uses associated values and custom `RawRepresentable` conformance.
+///
+/// - Note: This is an experimental pattern showcasing macro flexibility.
+@OptionSet<UInt8>
+struct DocumentationConfiguration: Sendable {
+	/// The current detalization level for documentation output.
+	public fileprivate(set) var detalizationValue: Detalization = .default
+	
+	/// Creates a configuration from a detalization level.
+	/// - Parameter detalization: The desired detalization level.
+	public init(rawValue detalization: Detalization) {
+		self = .init(rawValue: detalization.rawValue)
+	}
+	
+	/// Internal options enum with associated value support.
+	/// Demonstrates custom `RawRepresentable` conformance for complex option patterns.
+	private enum Options: Hashable, Sendable, CaseIterable, RawRepresentable {
+		case detalization(_ volume: Detalization)
+		
+		public static let detalization: Self = .detalization(.default)
+		
+		var rawValue: UInt {
+			switch self {
+			case .detalization(.concise): 1
+			case .detalization(.regular): 2
+			case .detalization(.detailed): 3
+			}
+		}
+		
+		static let allCases: [DocumentationConfiguration.Options] =
+			Detalization.allCases.map(DocumentationConfiguration.Options.detalization(_:))
+		
+		
+		init?(rawValue: UInt) {
+			if let correspondingCase = Self.allCases.first(where: { $0.rawValue == rawValue }) {
+				self = correspondingCase
+			} else {
+				return nil
+			}
+		}
+		
+	}
+	
+	/// Defines the verbosity level for documentation generation.
+	enum Detalization: UInt8, Hashable, Sendable, CaseIterable {
+		/// Minimal documentation output.
+		case concise
+		/// Standard documentation output.
+		case regular
+		/// Comprehensive documentation with all details.
+		case detailed
+		
+		/// The default detalization level (`.regular`).
+		public static let `default`: Self = .regular
+	}
+}
+

--- a/Tests/HelperTests/StringHelperTests.swift
+++ b/Tests/HelperTests/StringHelperTests.swift
@@ -274,5 +274,35 @@ struct StringHelperTests {
 			#expect(words.isEmpty)
 		}
 	}
+	
+	@Suite("capitalizingFirstLetter")
+	struct CapitalizingFirstLetterTests {
+		
+		@Test("Capitalizes first letter of lowercase word")
+		func capitalizesLowercaseWord() {
+			#expect("hello".capitalizingFirstLetter() == "Hello")
+		}
+		
+		@Test("Preserves already capitalized word")
+		func preservesCapitalizedWord() {
+			#expect("Hello".capitalizingFirstLetter() == "Hello")
+		}
+		
+		@Test("Handles single character")
+		func handlesSingleCharacter() {
+			#expect("a".capitalizingFirstLetter() == "A")
+			#expect("A".capitalizingFirstLetter() == "A")
+		}
+		
+		@Test("Returns empty for empty string")
+		func returnsEmptyForEmptyString() {
+			#expect("".capitalizingFirstLetter() == "")
+		}
+		
+		@Test("Preserves rest of string")
+		func preservesRestOfString() {
+			#expect("helloWORLD".capitalizingFirstLetter() == "HelloWORLD")
+		}
+	}
 }
 #endif

--- a/Tests/OptionSetTests/OptionSetMacroTests.swift
+++ b/Tests/OptionSetTests/OptionSetMacroTests.swift
@@ -372,5 +372,367 @@ struct OptionSetMacroTests {
 			indentationWidth: .spaces(2)
 		)
 	}
+	
+	// MARK: - Associated Enum Value Tests
+	
+	/// Tests that cases with associated nested enum values generate combined properties.
+	@Test("Generates properties for associated nested enum values")
+	func testAssociatedNestedEnumValues() {
+		assertMacroExpansion(
+			"""
+			@OptionSet<UInt8>
+			struct Configuration {
+				private enum Options {
+					case level(Priority)
+				}
+				
+				enum Priority {
+					case low
+					case medium
+					case high
+				}
+			}
+			""",
+			expandedSource: """
+				struct Configuration {
+					private enum Options {
+						case level(Priority)
+					}
+					
+					enum Priority {
+						case low
+						case medium
+						case high
+					}
+
+					typealias RawValue = UInt8
+
+					var rawValue: RawValue
+
+					init() {
+						self.rawValue = 0
+					}
+
+					init(rawValue: RawValue) {
+						self.rawValue = rawValue
+					}
+
+					static let levelLow: Self =
+						Self(rawValue: 1 << 0)
+
+					static let levelMedium: Self =
+						Self(rawValue: 1 << 1)
+
+					static let levelHigh: Self =
+						Self(rawValue: 1 << 2)
+				}
+
+				extension Configuration: OptionSet {
+				}
+				""",
+			macros: macros,
+			indentationWidth: .spaces(2)
+		)
+	}
+	
+	/// Tests mixing simple cases with associated enum value cases.
+	@Test("Mixes simple cases with associated enum values")
+	func testMixedSimpleAndAssociatedCases() {
+		assertMacroExpansion(
+			"""
+			@OptionSet<UInt8>
+			struct Settings {
+				private enum Options: Int {
+					case enabled
+					case theme(Theme)
+					case debug
+				}
+				
+				enum Theme {
+					case light
+					case dark
+				}
+			}
+			""",
+			expandedSource: """
+				struct Settings {
+					private enum Options: Int {
+						case enabled
+						case theme(Theme)
+						case debug
+					}
+					
+					enum Theme {
+						case light
+						case dark
+					}
+
+					typealias RawValue = UInt8
+
+					var rawValue: RawValue
+
+					init() {
+						self.rawValue = 0
+					}
+
+					init(rawValue: RawValue) {
+						self.rawValue = rawValue
+					}
+
+					static let enabled: Self =
+						Self(rawValue: 1 << Options.enabled.rawValue)
+
+					static let themeLight: Self =
+						Self(rawValue: 1 << 1)
+
+					static let themeDark: Self =
+						Self(rawValue: 1 << 2)
+
+					static let debug: Self =
+						Self(rawValue: 1 << Options.debug.rawValue)
+				}
+
+				extension Settings: OptionSet {
+				}
+				""",
+			macros: macros,
+			indentationWidth: .spaces(2)
+		)
+	}
+	
+	/// Tests that multiple associated enum value cases work correctly.
+	@Test("Multiple associated enum value cases")
+	func testMultipleAssociatedEnumCases() {
+		assertMacroExpansion(
+			"""
+			@OptionSet<UInt16>
+			struct DisplayOptions {
+				private enum Options {
+					case size(Size)
+					case color(Color)
+				}
+				
+				enum Size {
+					case small
+					case large
+				}
+				
+				enum Color {
+					case red
+					case blue
+					case green
+				}
+			}
+			""",
+			expandedSource: """
+				struct DisplayOptions {
+					private enum Options {
+						case size(Size)
+						case color(Color)
+					}
+					
+					enum Size {
+						case small
+						case large
+					}
+					
+					enum Color {
+						case red
+						case blue
+						case green
+					}
+
+					typealias RawValue = UInt16
+
+					var rawValue: RawValue
+
+					init() {
+						self.rawValue = 0
+					}
+
+					init(rawValue: RawValue) {
+						self.rawValue = rawValue
+					}
+
+					static let sizeSmall: Self =
+						Self(rawValue: 1 << 0)
+
+					static let sizeLarge: Self =
+						Self(rawValue: 1 << 1)
+
+					static let colorRed: Self =
+						Self(rawValue: 1 << 2)
+
+					static let colorBlue: Self =
+						Self(rawValue: 1 << 3)
+
+					static let colorGreen: Self =
+						Self(rawValue: 1 << 4)
+				}
+
+				extension DisplayOptions: OptionSet {
+				}
+				""",
+			macros: macros,
+			indentationWidth: .spaces(2)
+		)
+	}
+	
+	/// Tests that unknown associated value types fall back to simple generation.
+	@Test("Falls back to simple generation for unknown associated types")
+	func testUnknownAssociatedTypeFallback() {
+		assertMacroExpansion(
+			"""
+			@OptionSet<UInt8>
+			struct Config {
+				private enum Options {
+					case value(ExternalType)
+					case flag
+				}
+			}
+			""",
+			expandedSource: """
+				struct Config {
+					private enum Options {
+						case value(ExternalType)
+						case flag
+					}
+
+					typealias RawValue = UInt8
+
+					var rawValue: RawValue
+
+					init() {
+						self.rawValue = 0
+					}
+
+					init(rawValue: RawValue) {
+						self.rawValue = rawValue
+					}
+
+					static let value: Self =
+						Self(rawValue: 1 << 0)
+
+					static let flag: Self =
+						Self(rawValue: 1 << 1)
+				}
+
+				extension Config: OptionSet {
+				}
+				""",
+			macros: macros,
+			indentationWidth: .spaces(2)
+		)
+	}
+	
+	/// Tests associated enum values with public access modifier.
+	@Test("Associated enum values with public access modifier")
+	func testAssociatedEnumWithPublicAccess() {
+		assertMacroExpansion(
+			"""
+			@OptionSet<UInt8>
+			public struct PublicConfig {
+				private enum Options {
+					case mode(Mode)
+				}
+				
+				enum Mode {
+					case auto
+					case manual
+				}
+			}
+			""",
+			expandedSource: """
+				public struct PublicConfig {
+					private enum Options {
+						case mode(Mode)
+					}
+					
+					enum Mode {
+						case auto
+						case manual
+					}
+
+					public typealias RawValue = UInt8
+
+					public var rawValue: RawValue
+
+					public init() {
+						self.rawValue = 0
+					}
+
+					public init(rawValue: RawValue) {
+						self.rawValue = rawValue
+					}
+
+					public  static let modeAuto: Self =
+						Self(rawValue: 1 << 0)
+
+					public  static let modeManual: Self =
+						Self(rawValue: 1 << 1)
+				}
+
+				extension PublicConfig: OptionSet {
+				}
+				""",
+			macros: macros,
+			indentationWidth: .spaces(2)
+		)
+	}
+	
+	/// Tests associated enum with labeled parameter.
+	@Test("Associated enum with labeled parameter")
+	func testAssociatedEnumWithLabeledParameter() {
+		assertMacroExpansion(
+			"""
+			@OptionSet<UInt8>
+			struct Labeled {
+				private enum Options {
+					case priority(_ value: Level)
+				}
+				
+				enum Level {
+					case low
+					case high
+				}
+			}
+			""",
+			expandedSource: """
+				struct Labeled {
+					private enum Options {
+						case priority(_ value: Level)
+					}
+					
+					enum Level {
+						case low
+						case high
+					}
+
+					typealias RawValue = UInt8
+
+					var rawValue: RawValue
+
+					init() {
+						self.rawValue = 0
+					}
+
+					init(rawValue: RawValue) {
+						self.rawValue = rawValue
+					}
+
+					static let priorityLow: Self =
+						Self(rawValue: 1 << 0)
+
+					static let priorityHigh: Self =
+						Self(rawValue: 1 << 1)
+				}
+
+				extension Labeled: OptionSet {
+				}
+				""",
+			macros: macros,
+			indentationWidth: .spaces(2)
+		)
+	}
 }
 #endif

--- a/Tests/OptionSetTests/OptionSetMacroTests.swift
+++ b/Tests/OptionSetTests/OptionSetMacroTests.swift
@@ -480,7 +480,7 @@ struct OptionSetMacroTests {
 					}
 
 					static let enabled: Self =
-						Self(rawValue: 1 << Options.enabled.rawValue)
+						Self(rawValue: 1 << 0)
 
 					static let themeLight: Self =
 						Self(rawValue: 1 << 1)
@@ -489,7 +489,7 @@ struct OptionSetMacroTests {
 						Self(rawValue: 1 << 2)
 
 					static let debug: Self =
-						Self(rawValue: 1 << Options.debug.rawValue)
+						Self(rawValue: 1 << 3)
 				}
 
 				extension Settings: OptionSet {
@@ -728,6 +728,113 @@ struct OptionSetMacroTests {
 				}
 
 				extension Labeled: OptionSet {
+				}
+				""",
+			macros: macros,
+			indentationWidth: .spaces(2)
+		)
+	}
+	
+	/// Tests that property name collisions are resolved with numeric suffixes.
+	@Test("Resolves property name collisions with numeric suffixes")
+	func testPropertyNameCollisionResolution() {
+		assertMacroExpansion(
+			"""
+			@OptionSet<UInt8>
+			struct CollisionTest {
+				private enum Options {
+					case item(ItemType)
+					case itemA
+				}
+				
+				enum ItemType {
+					case a
+					case b
+				}
+			}
+			""",
+			expandedSource: """
+				struct CollisionTest {
+					private enum Options {
+						case item(ItemType)
+						case itemA
+					}
+					
+					enum ItemType {
+						case a
+						case b
+					}
+
+					typealias RawValue = UInt8
+
+					var rawValue: RawValue
+
+					init() {
+						self.rawValue = 0
+					}
+
+					init(rawValue: RawValue) {
+						self.rawValue = rawValue
+					}
+
+					static let itemA: Self =
+						Self(rawValue: 1 << 0)
+
+					static let itemB: Self =
+						Self(rawValue: 1 << 1)
+
+					static let itemA1: Self =
+						Self(rawValue: 1 << 2)
+				}
+
+				extension CollisionTest: OptionSet {
+				}
+				""",
+			macros: macros,
+			indentationWidth: .spaces(2)
+		)
+	}
+	
+	/// Tests that various BinaryInteger types work as RawValue.
+	@Test("Supports various BinaryInteger types")
+	func testBinaryIntegerSupport() {
+		assertMacroExpansion(
+			"""
+			@OptionSet<UInt>
+			struct LargeOptions {
+				private enum Options: Int {
+					case flag1
+					case flag2
+				}
+			}
+			""",
+			expandedSource: """
+				struct LargeOptions {
+					private enum Options: Int {
+						case flag1
+						case flag2
+					}
+
+					typealias RawValue = UInt
+
+					var rawValue: RawValue
+
+					init() {
+						self.rawValue = 0
+					}
+
+					init(rawValue: RawValue) {
+						self.rawValue = rawValue
+					}
+
+					static let flag1: Self =
+						Self(rawValue: 1 << Options.flag1.rawValue)
+
+					static let flag2: Self =
+						Self(rawValue: 1 << Options.flag2.rawValue)
+				}
+
+				extension LargeOptions: OptionSet {
 				}
 				""",
 			macros: macros,


### PR DESCRIPTION
## Overview

This PR adds support for associated enum values in the `@OptionSet` macro and fixes the Package.swift macro dependency structure.

## Changes

### 1. Package.swift Modernization (Commit 1)
- **Fixed macro dependency structure**: Replaced incorrect `plugins:` usage with proper macro target dependency
- **Added `QizhMacroKitPreviewSupport` library**: Separate target for Xcode canvas previews
- **Expanded access level support**: Added `fileprivate`, `package`, `internal`, `open` to `OptionSetGenerator`
- **Documentation improvements**: Added comprehensive docs for all changed code

### 2. Associated Enum Value Support (Commit 2)
The `@OptionSet` macro now supports cases with associated values of nested enum types.

```swift
@OptionSet<UInt8>
struct Configuration {
    private enum Options {
        case level(Priority)
        case theme(Theme)
        case enabled
    }
    enum Priority { case low, medium, high }
    enum Theme { case light, dark }
}
// Generated: .levelLow, .levelMedium, .levelHigh, .themeLight, .themeDark, .enabled
```

### 3. Critical Bug Fix (Commit 3) – *from @copilot review in PR #46*

**Issue**: Swift prohibits raw types on enums with associated values. When Options enum has ANY case with associated values, `.rawValue` doesn't exist on simple cases either.

**Fix**: Detect if ANY case has associated values → use manual bit indexing (`1 << index`) for ALL cases.

```swift
// Before (broken): Options.enabled.rawValue doesn't exist!
static let enabled: Self = Self(rawValue: 1 << Options.enabled.rawValue)

// After (fixed): Manual bit indexing for all
static let enabled: Self = Self(rawValue: 1 << 0)
static let themeLight: Self = Self(rawValue: 1 << 1)
```

**Additional fixes in this commit:**
- Name collision resolution with numeric suffixes (borrowed from `@CaseValue`)
- Fixed extra space in access modifiers

## Testing

- ✅ **133/133 tests pass** (`swift test --parallel`)
- ✅ **Build successful** (Swift 6.2, all targets)

### New Tests
1. Associated nested enum expansion
2. Mixed simple and associated cases  
3. Multiple associated enum types
4. Unknown type fallback behavior
5. Public access modifier preservation
6. Labeled parameters
7. **Property name collision resolution**
8. **BinaryInteger type support (UInt, UInt16, etc.)**

## Breaking Changes

None. All existing `@OptionSet` usage remains fully compatible.

---

<details><summary><h3>Previously in this PR</h3></summary>

Original PR description before critical bug fix.

</details>