### PR TITLE
Add version-specific Package.swift manifests for Xcode 26.2/26.3 compatibility

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/QizhMacroKit-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/QizhMacroKit-Package.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2620"
-   version = "1.7">
+   version = "2.1">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"
@@ -35,59 +35,14 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "QizhMacroKitTests"
-               BuildableName = "QizhMacroKitTests"
-               BlueprintName = "QizhMacroKitTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "QizhMacroKitPreviewSupport"
-               BuildableName = "QizhMacroKitPreviewSupport"
-               BlueprintName = "QizhMacroKitPreviewSupport"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <TestPlans>
-         <TestPlanReference
-            reference = "container:TestPlans/MacrosTestPlan.xctestplan"
-            default = "YES">
-         </TestPlanReference>
-      </TestPlans>
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "QizhMacroKitTests"
-               BuildableName = "QizhMacroKitTests"
-               BlueprintName = "QizhMacroKitTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -98,7 +53,9 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
+      allowLocationSimulation = "NO"
+      consoleMode = "0"
+      structuredConsoleMode = "2">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,6 +1,6 @@
 # Known Issues
 
-> Last Updated: January 13, 2026
+> Last Updated: January 14, 2026
 
 This document lists known limitations and issues in QizhMacroKit.
 
@@ -130,17 +130,94 @@ The diagnostic cases `associatedEnumNotFound` and `associatedEnumMissingCases` w
 
 ## External Issues
 
+### Xcode "No such module 'SwiftCompilerPlugin'" Error
+
+**Status**: Xcode Bug  
+**Affected**: Projects depending on QizhMacroKit when building for iOS  
+**Reported**: January 14, 2026  
+**Xcode Versions**: 26.x RC (and earlier versions)
+
+When building a project that depends on QizhMacroKit for an iOS destination, Xcode may incorrectly attempt to compile the macro target (`QizhMacroKitMacros`) for the destination platform instead of the host platform (macOS).
+
+**Symptoms**:
+
+- `No such module 'SwiftCompilerPlugin'` error in `_QizhMacroKitMacro.swift`
+- Error only appears when building for iOS/tvOS/watchOS destinations
+- `swift build` from terminal works correctly
+
+**Root Cause**: Xcode uses prebuilt swift-syntax modules that may be compiled with a different Swift compiler version than the one bundled with your Xcode. When there's a version mismatch, the modules become incompatible, causing cascading import failures for `SwiftSyntax`, `SwiftDiagnostics`, `SwiftSyntaxMacros`, `SwiftSyntaxBuilder`, and `SwiftCompilerPlugin`.
+
+**Build Log Indicators**:
+
+```text
+warning: Module file '...SwiftSyntax.swiftmodule...' is incompatible with this Swift compiler: compiled with a different version of the compiler
+```
+
+**Workarounds** (in order of effectiveness):
+
+1. **Reset Package Caches**:
+   - `File → Packages → Reset Package Caches`
+   - Clean build folder: `Cmd+Shift+K`
+
+2. **Delete DerivedData**:
+
+   ```zsh
+   rm -rf ~/Library/Developer/Xcode/DerivedData
+   ```
+
+3. **Trust Macros**: Check the Issue Navigator for "Trust & Enable" prompts
+
+4. **Restart Xcode** after resetting caches
+
+5. **Build for Mac first**, then switch to iOS destination
+
+#### If "Trust & Enable" Prompt Doesn't Appear
+
+If the standard workarounds don't help and the macro trust prompt never appears:
+
+1. **Force trust all macros** (temporary, has security implications):
+
+   ```zsh
+   defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
+   ```
+
+   Then restart Xcode. To revert:
+
+   ```zsh
+   defaults delete com.apple.dt.Xcode IDESkipMacroFingerprintValidation
+   ```
+
+2. **Reset macro trust preferences** to force the prompt to reappear:
+
+   ```zsh
+   rm -rf ~/Library/Developer/Xcode/UserData/IDEFingerprintStore/
+   ```
+
+   Then restart Xcode.
+
+3. **Build via xcodebuild** with the skip validation flag:
+
+   ```zsh
+   xcodebuild -skipMacroValidation -scheme YourScheme -destination 'platform=iOS Simulator,name=iPhone 16'
+   ```
+
+**Note**: This is NOT a bug in QizhMacroKit. The package configuration is correct — `swift build` works perfectly.
+
+---
+
 ### Codex Code Review GitHub Integration
 
 **Status**: OpenAI Backend Issue  
 **Reported**: January 13, 2026
 
 The Codex Code Review feature may fail to connect to GitHub repositories even when:
+
 - GitHub App is properly installed
 - Repository is in the authorized list
 - All permissions are granted
 
 **Symptoms**:
+
 - "Action required: Update your GitHub permissions" banner persists
 - "Update" button doesn't resolve the issue
 - Stale/phantom repositories appear in settings that cannot be removed

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cba61afa9bee6bf2006af5e4a0df8362e375d0a290c8c08e5ecf4c6a55d4c3fb",
+  "originHash" : "c87ad38885d31b39e53737b00894703f7abd378bb4dd327ea349f36ce980a592",
   "pins" : [
     {
       "identity" : "swift-docc-plugin",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
-        "version" : "602.0.0"
+        "revision" : "9b6d2d09c474336c8a5477a669ca976e58586f75",
+        "version" : "603.0.0-prerelease-2025-12-17"
       }
     }
   ],

--- a/Package@swift-6.2.4.swift
+++ b/Package@swift-6.2.4.swift
@@ -1,7 +1,9 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.2
 
-/// Package manifest for Swift 6.3+ toolchain
-/// See Package@swift-6.2.swift for Swift 6.2 toolchain (Xcode 26.2)
+/// Package manifest for Swift 6.2.4 toolchain (Xcode 26.3 RC)
+/// swift-syntax 602.0.0 prebuilts are incompatible with Swift 6.2.4
+/// See Package@swift-6.2.swift for Swift 6.2.0-6.2.3 (Xcode 26.2)
+/// See Package.swift for Swift 6.3+ toolchain
 
 import PackageDescription
 import CompilerPluginSupport
@@ -28,8 +30,7 @@ let package = Package(
 		),
 	],
 	dependencies: [
-		/// swift-syntax 603.x for Xcode 26.3+ compatibility
-		/// Note: 602.0.0 prebuilts are incompatible with Swift 6.2.4+ (Xcode 26.3 RC)
+		/// swift-syntax 603.x for Swift 6.2.4 compatibility
 		.package(
 			url: "https://github.com/swiftlang/swift-syntax.git",
 			from: "603.0.0-prerelease-2025-12-17"

--- a/Package@swift-6.2.swift
+++ b/Package@swift-6.2.swift
@@ -1,7 +1,8 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.2
 
-/// Package manifest for Swift 6.3+ toolchain
-/// See Package@swift-6.2.swift for Swift 6.2 toolchain (Xcode 26.2)
+/// Package manifest for Swift 6.2 toolchain (Xcode 26.2 and earlier)
+/// Note: Swift 6.2.4+ (Xcode 26.3 RC) may have incompatible prebuilt modules
+/// See Package.swift for Swift 6.3+ toolchain
 
 import PackageDescription
 import CompilerPluginSupport
@@ -28,11 +29,10 @@ let package = Package(
 		),
 	],
 	dependencies: [
-		/// swift-syntax 603.x for Xcode 26.3+ compatibility
-		/// Note: 602.0.0 prebuilts are incompatible with Swift 6.2.4+ (Xcode 26.3 RC)
+		/// swift-syntax 602.x for Swift 6.2 toolchain
 		.package(
 			url: "https://github.com/swiftlang/swift-syntax.git",
-			from: "603.0.0-prerelease-2025-12-17"
+			from: "602.0.0"
 		),
 		
 		/// DocC plugin (command plugin)


### PR DESCRIPTION
## Summary

Adds version-specific `Package.swift` manifests to support both Xcode 26.2 (Swift 6.2.0–6.2.3) and Xcode 26.3 RC (Swift 6.2.4) toolchains, which require different swift-syntax versions due to prebuilt module incompatibility.

## Problem

swift-syntax 602.0.0 prebuilts were compiled with an older Swift 6.2.x compiler. Swift 6.2.4 (Xcode 26.3 RC) cannot use these prebuilts, causing:
- "No such module 'SwiftCompilerPlugin'" errors
- "Module file is incompatible with this Swift compiler" warnings

## Solution

SwiftPM selects manifests by `swift-tools-version`, so we provide separate manifests:

| Manifest | Swift Version | swift-syntax |
|----------|---------------|--------------|
| `Package.swift` | 6.3+ | 603.x |
| `Package@swift-6.2.4.swift` | 6.2.4 | 603.x |
| `Package@swift-6.2.swift` | 6.2.0–6.2.3 | 602.x |

## Changes

### Commit 1: Consolidate testing to QizhMacroKitTests scheme
- Remove test-related entries from QizhMacroKit-Package and QizhMacroKitClient schemes

### Commit 2: Document Xcode macro trust issues and workarounds
- Document "No such module 'SwiftCompilerPlugin'" error symptoms and root cause
- Add workarounds: Clean Build Folder, Reset Package Caches, Trust macros
- Add additional workarounds for missing Trust & Enable prompt

### Commit 3: Add zsh preference to coding conventions
- Standardize on zsh for all command-line examples (macOS default shell)

### Commit 4: Add version-specific Package.swift manifests
- `Package.swift` (swift-tools-version: 6.3) → swift-syntax 603.x
- `Package@swift-6.2.4.swift` → swift-syntax 603.x
- `Package@swift-6.2.swift` → swift-syntax 602.x

### Commit 5: Update documentation
- Update README.md and AGENTS.md dependency sections

## Testing

- `swift build`: ✅ success (Swift 6.2.4)
- `swift test`: ✅ 133 tests passed

## Release

Tagged as `1.5.0`